### PR TITLE
atom_name (type) extended to 20 chars, element extended to 6 chars

### DIFF
--- a/Src/create_nonbond_table.f90
+++ b/Src/create_nonbond_table.f90
@@ -58,7 +58,7 @@
   IMPLICIT NONE
 
   LOGICAL :: repeat_type
-  CHARACTER(8), DIMENSION(:), ALLOCATABLE :: temp_atomtypes ! same dimension as atom_name
+  CHARACTER(20), DIMENSION(:), ALLOCATABLE :: temp_atomtypes ! same dimension as atom_name
   INTEGER :: ii, is, ia, itype, jtype, iset,jset,k,itype_1,itype_2
   REAL(DP) :: eps_i, eps_j, sig_i, sig_j
   INTEGER, DIMENSION(:,:), ALLOCATABLE :: vdw_param_set
@@ -150,7 +150,7 @@
      WRITE(logunit,'(A)') &
           ' There are '//TRIM(Int_To_String(nbr_atomtypes))//' different atom types in the system '
      DO ii = 1, nbr_atomtypes
-        WRITE(logunit,'(3x,I3,2x,A8)') ii, temp_atomtypes(ii)
+        WRITE(logunit,'(3x,I3,2x,A20)') ii, temp_atomtypes(ii)
      ENDDO
 
      WRITE(logunit,*)
@@ -163,7 +163,7 @@
 
         IF (natoms(is) < 100) THEN
           DO ia = 1, natoms(is)
-             WRITE(logunit,'(X,A8,T12,I4)') nonbond_list(ia,is)%atom_name, &
+             WRITE(logunit,'(X,A20,T12,I4)') nonbond_list(ia,is)%atom_name, &
                   nonbond_list(ia,is)%atom_type_number
           ENDDO
         ELSE

--- a/Src/input_routines.f90
+++ b/Src/input_routines.f90
@@ -1419,8 +1419,24 @@ SUBROUTINE Get_Atom_Info(is)
            ENDIF
 
            ! Assign appropriate values to list elements
-           nonbond_list(ia,is)%atom_name = line_array(2)
-           nonbond_list(ia,is)%element = line_array(3)
+           ! Error checking for length of atom_name and element name
+           IF ( LEN_TRIM(line_array(2)) .GT. 20 ) THEN
+             err_msg = ''
+             err_msg(1) = 'Atom name ' // TRIM(line_array(2)) // ' greater than '
+             err_msg(2) = 'max allowed length of 20 characters.'
+             CALL Clean_Abort(err_msg,'Get_Atom_Info')
+           ELSE
+             nonbond_list(ia,is)%atom_name = line_array(2)
+           ENDIF
+
+           IF ( LEN_TRIM(line_array(3)) .GT. 6 ) THEN
+             err_msg = ''
+             err_msg(1) = 'Element name ' // TRIM(line_array(3)) // ' greater than '
+             err_msg(2) = 'max allowed length of 6 characters.'
+             CALL Clean_Abort(err_msg,'Get_Atom_Info')
+           ELSE
+             nonbond_list(ia,is)%element = line_array(3)
+           ENDIF
            nonbond_list(ia,is)%mass = String_To_Double(line_array(4))
            nonbond_list(ia,is)%charge = String_To_Double(line_array(5))
            IF(nonbond_list(ia,is)%charge .NE. 0.0_DP) has_charge(is) = .TRUE.

--- a/Src/participation.f90
+++ b/Src/participation.f90
@@ -518,12 +518,14 @@ SUBROUTINE Participation
 
                  ! Check to see if this atom is a ring fragment, if so append, 'ring' at the end
 
-                    
-                 WRITE(201,'(I5,2X,2(A8,2X),2(F11.7,2X),A6,2X)',ADVANCE='NO') i, &
+                 WRITE(201,'(I5,2X,A20,2X,A6,2X,2(F11.7,2X),A6,2X)',ADVANCE='NO') i, &
                       nonbond_list(this_atom,is)%atom_name, nonbond_list(this_atom,is)%element, &
                       nonbond_list(this_atom,is)%mass, nonbond_list(this_atom,is)%charge, &
                       nonbond_list(this_atom,is)%vdw_type
                  DO j = 1, nbr_vdw_params(is)
+                   ! RSD TODO: Looks like we are always assuming the first vdw param is energy
+                   ! and all other do not need to be scaled by kboltz. Valid for LJ and Mie.
+                   ! Other (and future) potentials perhaps not.
                    IF (j == 1) THEN
                      WRITE(201,'(F11.7,2X)',ADVANCE='NO') nonbond_list(ia,is)%vdw_param(j)/kboltz
                    ELSE
@@ -541,7 +543,7 @@ SUBROUTINE Participation
            ELSE
               
               WRITE(201,*) bondpart_list(ia,is)%nbonds + 1
-              WRITE(201,'(I5,2X,2(A8,2X),2(F11.7,2X),A6,2X)',ADVANCE='NO') anchor_atom, &
+              WRITE(201,'(I5,2X,A20,2X,A6,2X,2(F11.7,2X),A6,2X)',ADVANCE='NO') anchor_atom, &
                         nonbond_list(ia,is)%atom_name, &
                         nonbond_list(ia,is)%element, &
                         nonbond_list(ia,is)%mass, &
@@ -574,7 +576,7 @@ SUBROUTINE Participation
                  
                  this_atom = frag_list(ifrag,is)%atoms(i)
                  
-                 WRITE(201,'(I5,2X,2(A8,2X),2(F11.7,2X),A6,2X)',ADVANCE='NO') i, &
+                 WRITE(201,'(I5,2X,A20,2X,A6,2X,2(F11.7,2X),A6,2X)',ADVANCE='NO') i, &
                                 nonbond_list(this_atom,is)%atom_name, &
                                 nonbond_list(this_atom,is)%element, &
                                 nonbond_list(this_atom,is)%mass, &

--- a/Src/type_definitions.f90
+++ b/Src/type_definitions.f90
@@ -220,8 +220,8 @@ MODULE Type_Definitions
      CHARACTER(20) :: vdw_type
      REAL(DP), DIMENSION(max_nonbond_params) :: vdw_param
 
-     CHARACTER(2) :: element
-     CHARACTER(8) :: atom_name
+     CHARACTER(6) :: element
+     CHARACTER(20) :: atom_name
 
      REAL(DP) :: mass, charge
      INTEGER :: atom_type_number


### PR DESCRIPTION
Addressing the issue mentioned on slack. Error checking was added when reading the atom name and element names from the MCF file. I think I traced through all the locations that `atom_name` or `element` are referenced. Passed local tests: (1) correctly threw error for too-long `atom_name`, (2) correctly threw error for too-long `element`, (3) ran for `LEN(atom_name) .GT. 6` OPLS-AA ethane system and calculated correct LJ energy, addressing previous issue. 

The current PR is to merge into the `develop` branch but these changes could also be merged into the `master` branch. Was a bit unsure of the current workflow. 