### PR TITLE
Clarifying Run_Type error message

### DIFF
--- a/Src/input_routines.f90
+++ b/Src/input_routines.f90
@@ -5132,7 +5132,8 @@ SUBROUTINE Get_Run_Type
 
            IF (nbr_entries /= 3) THEN
               err_msg = ''
-              err_msg(1) = 'Equilibration specified without the volume update'
+              err_msg(1) = 'Frequency to print/update the volume displacement'
+              err_msg(2) = 'must be specified for simulations with volume moves'
               CALL Clean_Abort(err_msg,'Get_Run_Type')
            END IF
 


### PR DESCRIPTION
It was brought to our attention that the error message if you fail to specify two integers for a production Run_Type with volume moves is somewhat misleading. This PR changes the error message that is printed to screen.  