### PR TITLE
Update to get_deps for iso_fortran_env

### DIFF
--- a/Src/get_deps
+++ b/Src/get_deps
@@ -16,5 +16,6 @@ done
 
 sed -ibkp s/\ netcdf.o/\ / dep.mk
 sed -ibkp s/omp_lib.o// dep.mk
+sed -ibkp s/iso_fortran_env.o// dep.mk
 rm dep.mkbkp
 


### PR DESCRIPTION
Edit to get_deps so that `iso_fortran_env.o` is removed from `dep.mk`. 