### PR TITLE
Create name for checkpoint file

### DIFF
--- a/Src/input_routines.f90
+++ b/Src/input_routines.f90
@@ -107,7 +107,10 @@ SUBROUTINE Get_Run_Name
   IF (input_is_logfile) THEN
      run_name = TRIM(run_name) // "_logfile_"
   END IF
- 
+
+  ! Get the checkpoint filename
+  CALL Name_Files(run_name,'.chk',checkpointfile)
+
 END SUBROUTINE Get_Run_Name
 
 !******************************************************************************


### PR DESCRIPTION
Bug fix.

Somewhere in a previous commit, likely when the `IF (input_is_logfile)` statement was added, the `Name_Files` call for `checkpointfile` was removed. This means the `checkpointfile` variable is never set. The first time Cassandra tries to write the checkpoint file the code fails.