### PR TITLE
Add python2/python3 support to scripts with futurize 

### DIFF
--- a/Documentation/Tex/utilities.tex
+++ b/Documentation/Tex/utilities.tex
@@ -1,8 +1,8 @@
 \chapter{Utilities}
 
 All Python utility scripts require the \texttt{future} package
-and \texttt{numpy} package, as listed in requirements-py.txt. Both packages
-are available via \texttt{pip} or \texttt{conda}.
+and \texttt{numpy} package, as listed in \texttt{requirements-py.txt}.
+Both packages are available via \texttt{pip} or \texttt{conda}.
 
 Please note that \texttt{python2} support is deprecated and may be removed
 in a future release.
@@ -59,7 +59,7 @@ in a future release.
 \section{Generate a Molecular Connectivity File}
 \label{sec:mcfgen}
 
-The script \texttt{mcf\_gen.py} is a tool that aims to ease the setup of molecular connectivity files from scratch (see section \ref{sec:MCF_File} to learn more
+The script \texttt{mcfgen.py} is a tool that aims to ease the setup of molecular connectivity files from scratch (see section \ref{sec:MCF_File} to learn more
 about MCFs), as the generation of these files by hand can be error prone. 
 In this section, a pentane MCF will be generated to demonstrate the use of this tool.
 The Transferable Potentials for Phase Equilibria (TraPPE) force field will be used to represent the pentane molecular interactions. 

--- a/Documentation/Tex/utilities.tex
+++ b/Documentation/Tex/utilities.tex
@@ -1,5 +1,12 @@
 \chapter{Utilities}
 
+All Python utility scripts require the \texttt{future} package
+and \texttt{numpy} package, as listed in requirements-py.txt. Both packages
+are available via \texttt{pip} or \texttt{conda}.
+
+Please note that \texttt{python2} support is deprecated and may be removed
+in a future release.
+
 %\section{Input File GUI} 
 %\label{sec:GUI}
 %This script provides a graphical user interface (GUI) with which the user 

--- a/Scripts/Frag_Library_Setup/library_setup.py
+++ b/Scripts/Frag_Library_Setup/library_setup.py
@@ -45,6 +45,10 @@
 #*******************************************************************************
 # IMPORT MODULES
 #*******************************************************************************
+from __future__ import print_function
+from builtins import input
+from builtins import str
+from builtins import range
 import sys, math, subprocess, os, linecache, argparse, re
 
 #*******************************************************************************
@@ -131,10 +135,10 @@ def cml_to_pdb(infilename):
 		if '</atomArray>' in line:
 			cml_end_atom = line_nbr + 1
 
-	for i in xrange(cml_start_atom+1, cml_end_atom):
+	for i in range(cml_start_atom+1, cml_end_atom):
 		cml_atom_info.append(re.findall('"([^"]*)"',linecache.getline(infilename, i)))
 			
-	for i in xrange(cml_start_bonds+1, cml_end_bonds):
+	for i in range(cml_start_bonds+1, cml_end_bonds):
 		cml_bond_info.append(re.findall('"([^"]*)"',linecache.getline(infilename, i))[0].split())
 
 	temp=[]
@@ -254,9 +258,9 @@ bold = '\033[1m'
 normal = '\033[0m'
 gcmc_flag = 0
 
-print bold+"\n********************** Cassandra Setup *********************\n"+normal
-print bold+"Cassandra location: "+normal+cassandra_path
-print bold+"Scanning input file"+normal
+print(bold+"\n********************** Cassandra Setup *********************\n"+normal)
+print(bold+"Cassandra location: "+normal+cassandra_path)
+print(bold+"Scanning input file"+normal)
 
 #Locate line number for the following keywords:
 # Nbr_Species
@@ -314,23 +318,23 @@ if nbr_boxes == 1:
 else:
 	vdw_style = []
 	charge_style = []
-	for i in xrange(1,nbr_boxes+1):
+	for i in range(1,nbr_boxes+1):
 		vdw_style.append(linecache.getline(input_file, vdw_style_line+i).split()[0])
 		if charge_style_line:
 			charge_style.append(linecache.getline(input_file, charge_style_line+i).split()[0])
 	if vdw_style[1] != vdw_style[0]:
-		vdw_style = raw_input("VDW_Style for boxes don't match. " +
+		vdw_style = input("VDW_Style for boxes don't match. " +
 		                      "Enter the VDW_Style to use (" + vdw_style[0] + "/" + 
 		                      vdw_style[i-1] + "):")
 	else:
 		vdw_style = vdw_style[0]
 	if vdw_style != 'LJ' and vdw_style != 'lj' and \
 	   vdw_style != 'Mie' and vdw_style != 'mie':
-		print "Only 'LJ' and 'Mie' VDW_Styles are supported"
+		print("Only 'LJ' and 'Mie' VDW_Styles are supported")
 		quit()
 	if charge_style_line:
 		if charge_style[1] != charge_style[0]:
-			charge_style = raw_input("Charge_Style for boxes don't match. " +
+			charge_style = input("Charge_Style for boxes don't match. " +
 										 "Enter the Charge_Style to use (" + charge_style[0] + "/" + 
 										 charge_style[i-1] + "):")
 		else:
@@ -341,12 +345,12 @@ sim_type = linecache.getline(input_file,sim_type_line+1)
 
 #Obtain number of species
 nbr_species = int(linecache.getline(input_file,nbr_species_line+1))
-print bold+"  Number of species found: " + normal + str(nbr_species)
+print(bold+"  Number of species found: " + normal + str(nbr_species))
 
 #Intra_Scaling
 vdw_scaling = []
 charge_scaling = []
-for i in xrange(1,nbr_species+1):
+for i in range(1,nbr_species+1):
 	if intra_scaling_line:
 		if charge_style_line and charge_style == 'coul':
 			vdw_scaling.append(linecache.getline(input_file,intra_scaling_line+2*i-1))
@@ -384,15 +388,15 @@ for this_species,each_pdb in enumerate(pdb_files):
 
 #Look for MCF files
 mcf_files = []
-for i in xrange(0,nbr_species):
+for i in range(0,nbr_species):
 	mcf_files.append(linecache.getline(input_file,molec_files_line+i+1).split()[0])
-	print bold+"  The MCF file number " + str(i+1) + " is: " + normal + mcf_files[i]
+	print(bold+"  The MCF file number " + str(i+1) + " is: " + normal + mcf_files[i])
 
 #Open the MCF files to record where atom, bond and fragment info is
 line_where_atom_info = []
 line_where_bond_info = []
 line_where_fragment_info = []
-for i in xrange(0,len(mcf_files)):
+for i in range(0,len(mcf_files)):
 	current_mcf = open(mcf_files[i],'r')
 	for line_number_mcf, line_mcf in enumerate(current_mcf):
 		if not line_mcf.strip():
@@ -411,11 +415,11 @@ atom_type_list = [0]*nbr_species
 which_atoms_are_ring = []
 temp_list = []
 nbr_atoms = []
-for i in xrange(0, nbr_species):
+for i in range(0, nbr_species):
 	nbr_atoms.append(int(linecache.getline(mcf_files[i],
 	                     line_where_atom_info[i]+1).split()[0]))
 	atom_type_list[i] = [0]*nbr_atoms[i]
-	for j in xrange(0,nbr_atoms[i]):
+	for j in range(0,nbr_atoms[i]):
 		atom_type = linecache.getline(mcf_files[i],
 		                              line_where_atom_info[i]+2+j).split()[1]
 		#remove old '_s?' flags if present
@@ -435,12 +439,12 @@ for i in xrange(0, nbr_species):
 #Find how many fragments there are and get a list of them.
 nbr_fragments = []
 fragment_list = []
-for i in xrange(0, nbr_species):
+for i in range(0, nbr_species):
 	nbr_fragments.append(int(linecache.getline(mcf_files[i],
 	                            line_where_fragment_info[i]+1).split()[0]))
-	print bold+"    Species "+str(i+1)+" has "+str(nbr_fragments[i])+ " fragments" + normal
+	print(bold+"    Species "+str(i+1)+" has "+str(nbr_fragments[i])+ " fragments" + normal)
 	temp_list=[]
-	for j in xrange(0,nbr_fragments[i]):
+	for j in range(0,nbr_fragments[i]):
 		temp_list.append(linecache.getline(mcf_files[i],
 		                 line_where_fragment_info[i]+2+j).split()[2:])
 	fragment_list.append(temp_list)
@@ -466,9 +470,9 @@ for i,species in enumerate(fragment_list):
 	temp_exoring = []
 
 if any([any(has_ring) for has_ring in fragment_has_ring]):
-	print bold+"Molecules with rings found. These are:" + normal
+	print(bold+"Molecules with rings found. These are:" + normal)
 	for i,species in enumerate(fragment_has_ring):
-		print bold+"Species "+str(i+1)+" has "+str(sum(species))+ " rings."+normal
+		print(bold+"Species "+str(i+1)+" has "+str(sum(species))+ " rings."+normal)
 
 #We know what fragments are ring for each species. Copy only those config_files 
 #for the species that have rings
@@ -489,16 +493,16 @@ for ispecies,has_ring in enumerate(fragment_has_ring):
 temperature = float(linecache.getline(input_file,temp_line+1).split()[0])
 
 #Rewrite the MCF files to append an '_s1' to the atom type
-for i in xrange(0,len(mcf_files)):
+for i in range(0,len(mcf_files)):
 	current_mcf = open(mcf_files[i],'r')
 	new_mcf_file = open(mcf_files[i]+"temp",'w')
 	total_lines = len(current_mcf.readlines())
 	current_mcf.close()
 	stride = 0
-	for line_number in xrange(1,total_lines+1):
+	for line_number in range(1,total_lines+1):
 		if line_number + stride > line_where_atom_info[i]+1 and \
 		   line_number + stride <= line_where_atom_info[i]+1 + nbr_atoms[i]:
-			for j in xrange(0,nbr_atoms[i]):
+			for j in range(0,nbr_atoms[i]):
 				this_line = linecache.getline(mcf_files[i],line_number+j+stride).split()
 				this_line[1] = atom_type_list[i][j]
 				new_mcf_file.write('    '.join(this_line)+'\n')
@@ -522,23 +526,23 @@ for i in xrange(0,len(mcf_files)):
 #/species?/fragments
 #/species?/frag?
 
-for i in xrange(0, nbr_species):
+for i in range(0, nbr_species):
 
-	for j in xrange(0,nbr_fragments[i]):
+	for j in range(0,nbr_fragments[i]):
 		os.system("mkdir -p species"+str(i+1)+"/frag"+str(j+1))
 
 	if i not in pdb_without_conect: 
 		os.system("mkdir -p species"+str(i+1)+"/fragments/")
 
 #Now, create input files for fragment MCF generation
-for i in xrange(0, nbr_species):
+for i in range(0, nbr_species):
 
 	if i in pdb_without_conect:
-		print "\n\n" + bold + "MCF generation file not created for species "+str(i+1)+normal
+		print("\n\n" + bold + "MCF generation file not created for species "+str(i+1)+normal)
 		if nbr_fragments[i] == 0:
-			print bold+"No fragment configuration needed."+normal
+			print(bold+"No fragment configuration needed."+normal)
 		else:
-			print bold+"Fragment configuration will be taken from PDB file."+normal
+			print(bold+"Fragment configuration will be taken from PDB file."+normal)
 		continue
 
 	if nbr_atoms[i] >= 3:
@@ -546,7 +550,7 @@ for i in xrange(0, nbr_species):
 			if str(i) in element[0]:
 				os.system("cp "+element[1]+" species"+str(i+1)+"/fragments/molecule.pdb")
 
-		print "\n\n"+bold+"Creating input MCF generation file for species "+str(i+1)+" "+normal
+		print("\n\n"+bold+"Creating input MCF generation file for species "+str(i+1)+" "+normal)
 		input_mcf_gen = open("species"+str(i+1)+"/fragments/species"+str(i+1)+"_mcf_gen.inp",'w')
 		input_mcf_gen.write("# Run_Name\nspecies"+str(i+1)+"_mcf_gen")
 		input_mcf_gen.write("\n\n")
@@ -570,7 +574,7 @@ for i in xrange(0, nbr_species):
 		input_mcf_gen.write("# Box_Info\n1\nCUBIC\n30.0 30.0 30.0\n\nEND")
 		input_mcf_gen.close()
 
-		print bold+"Running Cassandra to generate MCF files"+normal
+		print(bold+"Running Cassandra to generate MCF files"+normal)
 		sys.stdout.flush()
 		os.chdir('./species'+str(i+1)+'/fragments/')
 		subprocess.call([cassandra_path,'species'+str(i+1)+'_mcf_gen.inp'])
@@ -580,7 +584,7 @@ for i in xrange(0, nbr_species):
 #Test if fragment and/or ring is rigid
 fragment_is_rigid = [] # Boolean entry for each i,j
 ring_is_rigid = [] # frag_id's for each frag that has a rigid ring
-for i in xrange(0, nbr_species):
+for i in range(0, nbr_species):
 
 	if nbr_atoms[i] < 3:
 
@@ -595,7 +599,7 @@ for i in xrange(0, nbr_species):
 	else:
 		temp_rigid = []
 		temp_ring_rigid = []
-		for j in xrange(0,nbr_fragments[i]):
+		for j in range(0,nbr_fragments[i]):
 			#Read mcf to see how many angles are fixed
 			frag_atoms_are_ring = []
 			angle_parms = {}
@@ -606,14 +610,14 @@ for i in xrange(0, nbr_species):
 			while line:
 				if "# Atom_Info" in line:
 					nbr_frag_atoms = int(frag_mcf.readline().split()[0])
-					for k in xrange(0,nbr_frag_atoms):
+					for k in range(0,nbr_frag_atoms):
 						line = frag_mcf.readline()
 						atom_ID = int(line.split()[0])
 						if line.split()[-1] == 'ring':
 							frag_atoms_are_ring.append(atom_ID)
 				elif "# Angle_Info" in line:
 					nbr_angles = int(frag_mcf.readline().split()[0])
-					for k in xrange(0,nbr_angles):
+					for k in range(0,nbr_angles):
 						line = frag_mcf.readline()
 						angle_ID = tuple([int(x) for x in line.split()[1:4]])
 						angle_type = line.split()[4]
@@ -629,7 +633,7 @@ for i in xrange(0, nbr_species):
 				if temp_rigid[j]:
 					#If the whole frag is rigid, the ring must be rigid
 					temp_ring_rigid.append(j)
-				elif any([angle_type == 'fixed' for angle_type in angle_parms.values()]):
+				elif any([angle_type == 'fixed' for angle_type in list(angle_parms.values())]):
 					#Must have some 'fixed' angles to have a rigid ring
 					nbr_ring_angles_fixed = 0
 					for angle_ID in angle_parms:
@@ -644,8 +648,8 @@ for i in xrange(0, nbr_species):
 
 #Create input file for each fragment of each species
 
-for i in xrange(0, nbr_species):
-	for j in xrange(0,nbr_fragments[i]):
+for i in range(0, nbr_species):
+	for j in range(0,nbr_fragments[i]):
 		if fragment_is_rigid[i][j]:
 			#Read PDB
 			atom_coords = read_pdb(pdb_files[i])
@@ -661,8 +665,8 @@ for i in xrange(0, nbr_species):
 			output_frag.close()
 		else:
 			if fragment_has_ring[i][j]:
-				print bold+"Generating RING FRAGMENT library species "+str(i+1)+\
-									 " fragment "+str(j+1)+normal
+				print(bold+"Generating RING FRAGMENT library species "+str(i+1)+\
+									 " fragment "+str(j+1)+normal)
 				input_frag = open("species"+str(i+1)+"/frag"+str(j+1)+"/frag"+str(j+1)+
 													".inp",'w')
 				input_frag.write("# Run_Name\nfrag"+str(j+1)+"\n\n")
@@ -714,8 +718,8 @@ for i in xrange(0, nbr_species):
 				subprocess.call([cassandra_path,'frag'+str(j+1)+'.inp'])
 				os.chdir('../../')
 			else:
-				print bold+"Generating fragment library species "+str(i+1)+\
-					         " fragment " + str(j+1)+normal
+				print(bold+"Generating fragment library species "+str(i+1)+\
+					         " fragment " + str(j+1)+normal)
 				input_frag = open("species"+str(i+1)+"/frag"+str(j+1)+"/frag"+str(j+1)+
 					                ".inp",'w')
 				input_frag.write("# Run_Name\nfrag"+str(j+1)+"\n\n")
@@ -764,13 +768,13 @@ new_file = open(input_file+"temp",'w')
 total_lines = len(in_file.readlines())
 in_file.close()
 omit = False
-for line_number in xrange(1,total_lines+1):
+for line_number in range(1,total_lines+1):
 	
 	if line_number == frag_files_line:
 		new_file.write("# Fragment_Files\n")
 		total_frag_counter = 0
-		for i in xrange(0, nbr_species):
-			for j in xrange(0,nbr_fragments[i]):
+		for i in range(0, nbr_species):
+			for j in range(0,nbr_fragments[i]):
 				total_frag_counter += 1
 				new_file.write("species"+str(i+1)+"/frag"+str(j+1)+"/frag"+str(j+1)+
 				               ".dat  " + str(total_frag_counter)+"\n")
@@ -788,6 +792,6 @@ for line_number in xrange(1,total_lines+1):
 in_file.close()
 new_file.close()
 
-print bold+"Removing temporary input file"+normal
+print(bold+"Removing temporary input file"+normal)
 os.system("rm "+ input_file+"; mv "+input_file+"temp "+input_file)
-print bold+"Finished"+normal
+print(bold+"Finished"+normal)

--- a/Scripts/Frag_Library_Setup/library_setup.py
+++ b/Scripts/Frag_Library_Setup/library_setup.py
@@ -50,6 +50,7 @@ from builtins import input
 from builtins import str
 from builtins import range
 import sys, math, subprocess, os, linecache, argparse, re
+import warnings
 
 #*******************************************************************************
 # ARGUMENT PARSE
@@ -795,3 +796,10 @@ new_file.close()
 print(bold+"Removing temporary input file"+normal)
 os.system("rm "+ input_file+"; mv "+input_file+"temp "+input_file)
 print(bold+"Finished"+normal)
+
+# Python 2.x deprecation warning
+if (sys.version_info < (3,0)):
+    warnings.showwarning("\n\nSupport for Python2 is deprecated in "
+        "Cassandra and will be removed in a future release. Please "
+        "consider switching to Python3.\n\n", DeprecationWarning,
+        'library_setup.py', 801)

--- a/Scripts/MCF_Generation/mcfgen.py
+++ b/Scripts/MCF_Generation/mcfgen.py
@@ -40,6 +40,7 @@ from builtins import input
 from builtins import range
 from past.utils import old_div
 import sys, os, argparse, linecache, re
+import warnings
 
 #*******************************************************************************
 # ARGUMENT PARSE
@@ -1459,3 +1460,10 @@ else:
 
 if infilename_type == 'cml':
 	os.system("rm " + configFile)
+
+# Python 2.x deprecation warning
+if (sys.version_info < (3,0)):
+    warnings.showwarning("\n\nSupport for Python2 is deprecated in "
+        "Cassandra and will be removed in a future release. Please "
+        "consider switching to Python3.\n\n", DeprecationWarning,
+        'library_setup.py', 1465)

--- a/Scripts/MCF_Generation/mcfgen.py
+++ b/Scripts/MCF_Generation/mcfgen.py
@@ -33,6 +33,12 @@
 #*******************************************************************************
 # IMPORT MODULES
 #*******************************************************************************
+from __future__ import division
+from __future__ import print_function
+from builtins import str
+from builtins import input
+from builtins import range
+from past.utils import old_div
 import sys, os, argparse, linecache, re
 
 #*******************************************************************************
@@ -292,11 +298,11 @@ def cml_to_pdb(infilename):
 		if '</atomArray>' in line:
 			cml_end_atom = line_nbr + 1
 
-	for i in xrange(cml_start_atom+1, cml_end_atom):
+	for i in range(cml_start_atom+1, cml_end_atom):
 		cml_atom_info.append(re.findall('"([^"]*)"',
 		                     linecache.getline(infilename, i)))
 			
-	for i in xrange(cml_start_bonds+1, cml_end_bonds):
+	for i in range(cml_start_bonds+1, cml_end_bonds):
 		cml_bond_info.append(re.findall('"([^"]*)"',
 		                     linecache.getline(infilename, i))[0].split())
 
@@ -368,9 +374,9 @@ def cml_to_pdb(infilename):
 
 
 def removeTempFromMaster(tempList,masterList):
-	for i in xrange(0,len(masterList)):
+	for i in range(0,len(masterList)):
 		if masterList[i] == tempList[0]:
-			for j in xrange(0,len(tempList)):
+			for j in range(0,len(tempList)):
 				del(masterList[-1])
 			return
 
@@ -428,7 +434,7 @@ returns:
 		isAlreadyInRing = any([newAtom in ring for ring in ringList])
 		if isAlreadyInRing:
 			if args.verbose:
-				print "%4d %-15s" % (newAtom, "already IDd as a ring atom, abort")
+				print("%4d %-15s" % (newAtom, "already IDd as a ring atom, abort"))
 			break
 
 		# if repeat atom has not been flagged as a ring atom, flag it now
@@ -436,7 +442,7 @@ returns:
 		isRing = newAtom in wRingList
 		if isRing:
 			if args.verbose:
-				print "%4d %-15s" % (newAtom, "repeat atom, must be a ring atom")
+				print("%4d %-15s" % (newAtom, "repeat atom, must be a ring atom"))
 			wRingList.append(newAtom)
 			if iRecursion == 1: # on deeper recursion, isolateRing will be called after exiting
 					isolateRing(wRingList)
@@ -449,7 +455,7 @@ returns:
 		# terminal, linear, branch
 		if nBonds==1: # terminal
 			if args.verbose:
-				print "%4d %-40s" % (newAtom, "terminal")
+				print("%4d %-40s" % (newAtom, "terminal"))
 
 			if len(scannedList) > 1: # only bonded atom is oldAtom
 				return "EndPoint", wBranchList
@@ -458,11 +464,11 @@ returns:
 
 		elif nBonds==2: # linear
 			if args.verbose: 
-				print "%4d %-40s" % (newAtom, "linear")
+				print("%4d %-40s" % (newAtom, "linear"))
 
 			# one bonded atom is oldAtom
 			# need to select the other atom
-			for i in xrange(nBonds):
+			for i in range(nBonds):
 
 				if newConnect[i]==oldAtom: # skip oldAtom
 					continue
@@ -472,11 +478,11 @@ returns:
 
 		elif nBonds > 2: # branch
 			if args.verbose:
-				print "%4d %-40s" % (newAtom, "branch")
+				print("%4d %-40s" % (newAtom, "branch"))
 
 			# loop over each atom newAtom is bonded to
 			# and call ringID() recursively
-			for j in xrange(nBonds):
+			for j in range(nBonds):
 				
 				if newConnect[j]==oldAtom: # skip oldAtom
 					continue
@@ -508,7 +514,7 @@ def fragID():
 			if nBonds > 2:
 				adjacentatoms.append(list(set(atomConnect[atom])-set(ring)))
 
-		adjacentatoms1=filter(None,adjacentatoms)
+		adjacentatoms1=[_f for _f in adjacentatoms if _f]
 		adjacentatoms = [x for sublist in adjacentatoms1 for x in sublist]
 		fragList.append(ring+adjacentatoms)
 		adjacentatoms=[]
@@ -660,14 +666,14 @@ def fragConnectivityInfo(mcfFile):
 
 def ffFileGeneration(infilename,outfilename):
 
-	print "\n\n*********Force field template file generation*********\n"
+	print("\n\n*********Force field template file generation*********\n")
 
 	global vdwType
-	vdwType = raw_input("Enter the VDW type (LJ/Mie):")
+	vdwType = input("Enter the VDW type (LJ/Mie):")
 
 	global dihedralType
 	if len(dihedralList) > 0:
-		dihedralType = raw_input("Enter the dihedral functional form " + 
+		dihedralType = input("Enter the dihedral functional form " + 
 		                         "(CHARMM/OPLS/harmonic/none): ")
 	else:
 		dihedralType = "NONE" 
@@ -826,7 +832,7 @@ returns:
 						if args.massDefault or args.massDefault==0:
 							atomParms[iType]['mass'] = args.massDefault
 						else:
-							iMass= raw_input("Atom type " + iType + " is of unknown element " 
+							iMass= input("Atom type " + iType + " is of unknown element " 
 							  + iElement + ". Enter the mass for this atom type: ")
 							atomParms[iType]['mass']=float(iMass)
 			elif 'element' in atomParms[iType] and \
@@ -1002,8 +1008,8 @@ returns:
 				includeFile, atomParms, bondParms, angleParms, dihedralParms, scaling_1_4,
 				vdwType, comboRule)
 			else:
-				print 'WARNING: Topology file ' + includeFile + ' not found. ' + \
-				      'Continuing without reading file.'
+				print('WARNING: Topology file ' + includeFile + ' not found. ' + \
+				      'Continuing without reading file.')
 		elif line.startswith('['):
 			section = line.strip() #store the section header
 			line = ff.readline()
@@ -1043,8 +1049,8 @@ returns:
 						if comboRule == '1':
 							C6 = float(data[base+1])
 							C12 = float(data[base+2])
-							sigma = ((C12 / C6)**(1/6.)) * 10
-							epsilon = C6**2 / 4 / C12 / Rg
+							sigma = ((old_div(C12, C6))**(1/6.)) * 10
+							epsilon = old_div(old_div(old_div(C6**2, 4), C12), Rg)
 						elif comboRule == '2' or comboRule == '3':
 							sigma = float(data[base+1]) * 10
 							epsilon = float(data[base+2]) / Rg
@@ -1380,44 +1386,44 @@ listofnames=[]
 cyclic_ua_atom = False
 
 # read configFile
-print "Reading Modified PDB File..."
+print("Reading Modified PDB File...")
 atomList, atomParms, atomConnect, bondList, numAtomTypes = readPdb(configFile)
 
 # ring scan
 if len(bondList) > 1:
 	if args.verbose:
-		print "%-5s%-40s" % ('Atom', 'Comment')
-		print "---- -----------------------------------"
+		print("%-5s%-40s" % ('Atom', 'Comment'))
+		print("---- -----------------------------------")
 	scannedList = [atomConnect['startRingID']]
 	scan_result = ringID(0)
 	if args.verbose:
-		print "---- -----------------------------------"
+		print("---- -----------------------------------")
 
 # print summary
-print "\n\n*********Generation of Topology File*********\n"
-print "Summary"
-print "---- -----------------------------------"
-print "%4d %-40s" % (len(bondList), "bonds")
+print("\n\n*********Generation of Topology File*********\n")
+print("Summary")
+print("---- -----------------------------------")
+print("%4d %-40s" % (len(bondList), "bonds"))
 
 if cyclic_ua_atom == True and len(scan_result[1]) > 2:
-	print "Cyclic united atom molecule with no branches"
+	print("Cyclic united atom molecule with no branches")
 else:
 	comment = "rings"
 	if len(ringList) > 0 and args.verbose:
 		comment += ":"
 		for ring in ringList:
 			comment += ' [' + ",".join([str(i) for i in ring]) + ']'
-	print "%4d %-40s" % (len(ringList), comment)
+	print("%4d %-40s" % (len(ringList), comment))
 
 # id angles, dihedrals, fragments
 angleID()
-print "%4d %-40s" % (len(angleList), "angles")
+print("%4d %-40s" % (len(angleList), "angles"))
 dihedralID()
-print "%4d %-40s" % (len(dihedralList), "dihedrals")
+print("%4d %-40s" % (len(dihedralList), "dihedrals"))
 fragID()
-print "%4d %-40s" % (len(fragList), "fragments")
+print("%4d %-40s" % (len(fragList), "fragments"))
 fragConnectivity()
-print "---- -----------------------------------"
+print("---- -----------------------------------")
 
 
 if ffTemplate:
@@ -1425,7 +1431,7 @@ if ffTemplate:
 	if os.path.isfile(ffFile) and not os.path.isfile(ffFile + '.BAK'):
 		os.system('mv ' + ffFile + ' ' + ffFile + '.BAK')
 	ffFileGeneration(configFile,ffFile)
-	print 'Finished'
+	print('Finished')
 else:
 	# GENERATE MCF FILE
 	# Read parms


### PR DESCRIPTION
## Description
Apply the `futurize` command to `mcfgen.py` and `library_setup.py` to make them compatible with both `python2` and `python3`. A deprecation warning was added for `python2`

## Related Issue
Closes #8 and provides backwards compatibility with `python2`

## Further Information, Files, and Links
This PR adds `python3` support with _minimal_ changes and backwards compatibility. In the future I will submit a PR for a more comprehensive update to `mcfgen.py` and `library_setup.py`. 
