### PR TITLE
Clarify error message for invalid VDW type in MCF file

### DIFF
--- a/Src/create_nonbond_table.f90
+++ b/Src/create_nonbond_table.f90
@@ -266,7 +266,7 @@
                  ENDIF
 
                  vdw_param_set(itype,itype) = 1
-              ELSE IF (nonbond_list(ia,is)%vdw_type == 'Mie') THEN
+              ELSE IF (nonbond_list(ia,is)%vdw_type == 'MIE') THEN
                  ! epsilon
                  IF (nonbond_list(ia,is)%vdw_param(1) <= tiny_number) THEN
                     vdw_param1_table(itype,itype) = 0.0_DP

--- a/Src/energy_routines.f90
+++ b/Src/energy_routines.f90
@@ -2389,7 +2389,7 @@ END SUBROUTINE Compute_Molecule_Self_Energy
 
    ELSE
       err_msg = ""
-      err_msg(1) = 'vdw_style must be NONE of LJ or Mie'
+      err_msg(1) = 'vdw_style must be NONE, LJ or Mie'
       CALL Clean_Abort(err_msg,'Compute_Atom_Nonbond_Energy')
 
    ENDIF VDW_Test2

--- a/Src/input_routines.f90
+++ b/Src/input_routines.f90
@@ -1400,10 +1400,10 @@ SUBROUTINE Get_Atom_Info(is)
         species_list(is)%molecular_weight = 0.0_DP
 
         DO ia = 1,natoms(is)
-           ! Now read the entries on the next lines. There must be at least 8 for
-           ! each atom.
+           ! Now read the entries on the next lines.
+           ! There must be at least 8 for each atom.
            line_nbr = line_nbr + 1
-           CALL Parse_String(molfile_unit,line_nbr,6,nbr_entries,line_array,ierr)
+           CALL Parse_String(molfile_unit,line_nbr,8,nbr_entries,line_array,ierr)
 
            ! Test for problems readin file
            IF (ierr /= 0) THEN

--- a/Src/input_routines.f90
+++ b/Src/input_routines.f90
@@ -1452,22 +1452,22 @@ SUBROUTINE Get_Atom_Info(is)
            ! Check valid VDW types
            SELECT CASE (nonbond_list(ia,is)%vdw_type)
 
-              CASE ("NONE" .OR. "None" .OR. "none")
+              CASE ("NONE", "None", "none")
                  nonbond_list(ia,is)%vdw_type = "NONE"
                  nbr_vdw_params(is) = 0
 
-              CASE ("LJ" .OR. "Lj" .OR. "lj")
+              CASE ("LJ", "Lj", "lj")
                  nonbond_list(ia,is)%vdw_type = "LJ"
                  nbr_vdw_params(is) = 2
 
-              CASE ("MIE" .OR. "Mie" .OR. "mie")
+              CASE ("MIE", "Mie", "mie")
                  nonbond_list(ia,is)%vdw_type = "MIE"
                  nbr_vdw_params(is) = 4
 
               CASE DEFAULT
                  err_msg = ''
                  err_msg(1) = 'Invalid vdw type ' // TRIM(nonbond_list(ia,is)%vdw_type)
-                 err_msg(2) = 'on line ' // TRIM(line_nbr) // 'of MCF file'
+                 err_msg(2) = 'on line number ' // TRIM(Int_To_String(line_nbr)) // ' of MCF file'
                  CALL Clean_Abort(err_msg, 'Get_Atom_Info')
 
            END SELECT
@@ -1476,7 +1476,7 @@ SUBROUTINE Get_Atom_Info(is)
            IF (nbr_entries < 6 + nbr_vdw_params(is)) THEN
               err_msg = ''
               err_msg(1) = 'VDW potential type ' // TRIM(nonbond_list(ia,is)%vdw_type)
-              err_msg(2) = 'requires ' // TRIM(nbr_vdw_params(is)) //  ' parameters'
+              err_msg(2) = 'requires ' // TRIM(Int_To_String(nbr_vdw_params(is))) //  ' parameters'
               CALL Clean_Abort(err_msg,'Get_Atom_Info')
            ENDIF
 

--- a/Src/input_routines.f90
+++ b/Src/input_routines.f90
@@ -406,7 +406,7 @@ SUBROUTINE Get_Pair_Style
            ! way it will be summed / truncated, and the remaining to parameters associated with
            ! the sum method
 
-           IF (line_array(1) == 'lj' .OR. line_array(1) == 'LJ') THEN
+           IF ( line_array(1) == 'LJ' .OR. line_array(1) == 'Lj' .OR. line_array(1) == 'lj' ) THEN
               vdw_style(ibox) = 'LJ'
               int_vdw_style(ibox) = vdw_lj
               WRITE(logunit,'(A,2x,A,A,I3)') 'VDW style used is: ',vdw_style(ibox), 'in box:', ibox
@@ -503,8 +503,8 @@ SUBROUTINE Get_Pair_Style
                  CALL Clean_Abort(err_msg,'Get_Pair_Style')
               ENDIF
 
-           ELSEIF (line_array(1) == 'mie' .OR. line_array(1) == 'Mie') THEN
-              vdw_style(ibox) = 'Mie'
+           ELSEIF ( line_array(1) == 'MIE' .OR. line_array(1) == 'Mie' .OR. line_array(1) == 'mie' ) THEN
+              vdw_style(ibox) = 'MIE'
               int_vdw_style(ibox) = vdw_mie
               WRITE(logunit,'(A,2x,A,A,I3)') 'VDW style used is: ',vdw_style(ibox), 'in box:', ibox
               vdw_sum_style(ibox) = line_array(2)


### PR DESCRIPTION
## Description
Each line of the `Atom_Info` section of an MCF file should have at least 6 entries plus the number of entries required for the specified VDW type. This PR rearranges the code that reads the `Atom_Info` section of the MCF file to use `SELECT CASE` and throw a clear error if the VDW type is not supported. 

This PR also:
* Stores vdw_style and vdw_type of the Mie potential in all caps, as "MIE" to be consistent with "NONE" and "LJ".
* Fixes a small typo in an error message in `energy_routines.f90`
* Fixes a small typo in the comment saying that each line of `Atom_Info` required 8 items when the code below checked for 6 items.
* Consolidates the section of code that checks for the correct number of items in each line of `Atom_Info` to a single check for all VDW types.

## Related Issue
Related to #52, but does not address the bug in `mcfgen.py`.

## How Has This Been Tested?
Test files [here](https://gist.github.com/rsdefever/8bb9b4a116e4939541a44cea6fb8aa22). `methane.mcf` works while `methane-nocharges.mcf` results in an error (stating that at least 8 entries are required) with the changes in this PR.

```
Invalid vdw type 148.000
on line number 11 of MCF file
This error occurred in subroutine Get_Atom_Info on step 0.
Fatal Error. Stopping program.
```