### PR TITLE
Add support for shifted-force LJ potential

### DIFF
--- a/Src/energy_routines.f90
+++ b/Src/energy_routines.f90
@@ -2362,7 +2362,8 @@ END SUBROUTINE Compute_Molecule_Self_Energy
             get_vdw = .FALSE.
          ENDIF
       ELSEIF (int_vdw_sum_style(this_box) == vdw_cut .OR. int_vdw_sum_style(this_box) &
-           == vdw_cut_shift .OR. int_vdw_sum_style(this_box) == vdw_cut_tail) THEN
+              == vdw_cut_shift .OR. int_vdw_sum_style(this_box) == vdw_cut_tail &
+              .OR. int_vdw_sum_style(this_box) == vdw_cut_force_shift ) THEN
 
          IF (rijsq <= rcut_vdwsq(this_box)) THEN
             get_vdw = .TRUE.
@@ -2752,6 +2753,16 @@ END SUBROUTINE Compute_Molecule_Self_Energy
            ELSEIF (int_vdw_sum_style(ibox) == vdw_charmm) THEN
              ! Use the CHARMM LJ potential
              Wij_vdw = (12.0_DP * eps) * (SigByR12 - SigByR6)
+           ELSEIF (int_vdw_sum_style(ibox) == vdw_cut_force_shift) THEN
+             ! shifted-force lj potential
+             ! u_sf(r) = u_lj(r) - u_lj(rc) - (r-rc)*du_lj/dr(rc)
+             SigByR2_shift = sig**2/rcut_vdwsq(ibox)
+             SigByR6_shift = SigByR2_shift * SigByR2_shift * SigByR2_shift
+             SigByR12_shift = SigByR6_shift * SigByR6_shift
+
+             Wij_vdw = (24.0_DP * eps) * (2.0_DP*SigByR12 - SigByR6)
+             Wij_vdw = Wij_vdw - &
+                       (24.0_DP * eps) * (2.0_DP*SigByR12_shift - SigByR6_shift)
            END IF
          ELSE IF (int_vdw_style(ibox) == vdw_mie) THEN
            eps = vdw_param1_table(itype,jtype)

--- a/Src/energy_routines.f90
+++ b/Src/energy_routines.f90
@@ -1268,7 +1268,7 @@ CONTAINS
                    ELSE IF (int_vdw_sum_style(ibox) == vdw_charmm) THEN
                          ! use the form for modified LJ potential
                          Eij_vdw = eps * (SigByR12 - 2.0_DP * SigByR6)
-                   ELSE IF (int_vdw_sum_style(ibox) == vdw_cut_force_shift) THEN
+                   ELSE IF (int_vdw_sum_style(ibox) == vdw_cut_shift_force) THEN
                          ! apply the shifted-force LJ potential
                          ! u_sf(r) = u_lj(r) - u_lj(rc) - (r-rc)*du_lj/dr(rc)
                          SigByR2_shift = sig**2/rcut_vdwsq(ibox)
@@ -2363,7 +2363,7 @@ END SUBROUTINE Compute_Molecule_Self_Energy
          ENDIF
       ELSEIF (int_vdw_sum_style(this_box) == vdw_cut .OR. int_vdw_sum_style(this_box) &
               == vdw_cut_shift .OR. int_vdw_sum_style(this_box) == vdw_cut_tail &
-              .OR. int_vdw_sum_style(this_box) == vdw_cut_force_shift ) THEN
+              .OR. int_vdw_sum_style(this_box) == vdw_cut_shift_force ) THEN
 
          IF (rijsq <= rcut_vdwsq(this_box)) THEN
             get_vdw = .TRUE.
@@ -2754,7 +2754,7 @@ END SUBROUTINE Compute_Molecule_Self_Energy
            ELSEIF (int_vdw_sum_style(ibox) == vdw_charmm) THEN
              ! Use the CHARMM LJ potential
              Wij_vdw = (12.0_DP * eps) * (SigByR12 - SigByR6)
-           ELSEIF (int_vdw_sum_style(ibox) == vdw_cut_force_shift) THEN
+           ELSEIF (int_vdw_sum_style(ibox) == vdw_cut_shift_force) THEN
              ! shifted-force lj potential
              ! u_sf(r) = u_lj(r) - u_lj(rc) - (r-rc)*du_lj/dr(rc)
              SigByR2_shift = sig**2/rcut_vdwsq(ibox)

--- a/Src/energy_routines.f90
+++ b/Src/energy_routines.f90
@@ -1274,25 +1274,17 @@ CONTAINS
                          SigByR2_shift = sig**2/rcut_vdwsq(ibox)
                          SigByR6_shift = SigByR2_shift * SigByR2_shift * SigByR2_shift
                          SigByR12_shift = SigByR6_shift * SigByR6_shift
-                         WRITE(*,*) "U_lj: ", Eij_vdw
+
                          Eij_vdw = Eij_vdw &
                                  - 4.0_DP * eps * (SigByR12_shift - SigByR6_shift)
 
-                         WRITE(*,*) "U_lj_potshift: ", Eij_vdw
                          rij = SQRT(rijsq)
                          rcut_vdw = SQRT(rcut_vdwsq(ibox))
-                         WRITE(*,*) "rij: ", rij 
-                         WRITE(*,*) "rcut: ", rcut_vdw
-                         WRITE(*,*) "eps: ", eps
-                         WRITE(*,*) "sig:", sig
-                         WRITE(*,*) "SigbyR12: ", SigByR12
-                         WRITE(*,*) "SigbyR6: ", SigByR6
 
                          dEij_dr = - 24.0_DP * eps * ( 2.0_DP * SigByR12_shift / rcut_vdw &
                                                       - SigByR6_shift / rcut_vdw )
 
                          Eij_vdw = Eij_vdw - (rij - rcut_vdw) * dEij_dr
-                         WRITE(*,*) "U_lj_forceshift: ", Eij_vdw
 
                    END IF
 
@@ -2705,6 +2697,7 @@ END SUBROUTINE Compute_Molecule_Self_Energy
     ! LJ potential
     INTEGER :: itype, jtype
     REAL(DP) :: eps, sig, Eij_vdw
+    REAL(DP) :: rij, rcut_vdw
     REAL(DP) :: SigByR2,SigByR6,SigByR12
     REAL(DP) :: SigByR2_shift,SigByR6_shift,SigByR12_shift
     REAL(DP) :: roffsq_rijsq, roffsq_rijsq_sq, factor2, fscale
@@ -2712,7 +2705,7 @@ END SUBROUTINE Compute_Molecule_Self_Energy
     REAL(DP) :: SigByR, SigByRn, SigByRm, mie_coeff, mie_n, mie_m
     ! Coulomb potential
     REAL(DP) :: qi, qj, erfc_val, prefactor
-    REAL(DP) :: rij, ewald_constant, exp_const
+    REAL(DP) :: ewald_constant, exp_const
 
     Wij_vdw = 0.0_DP
     Wij_qq = 0.0_DP
@@ -2767,10 +2760,13 @@ END SUBROUTINE Compute_Molecule_Self_Energy
              SigByR2_shift = sig**2/rcut_vdwsq(ibox)
              SigByR6_shift = SigByR2_shift * SigByR2_shift * SigByR2_shift
              SigByR12_shift = SigByR6_shift * SigByR6_shift
+             rij = SQRT(rijsq)
+             rcut_vdw = SQRT(rcut_vdwsq(ibox))
 
-             Wij_vdw = (24.0_DP * eps) * (2.0_DP*SigByR12 - SigByR6)
-             Wij_vdw = Wij_vdw - &
-                       (24.0_DP * eps) * (2.0_DP*SigByR12_shift - SigByR6_shift)
+             Wij_vdw = Wij_vdw &
+                       - rij * (24.0_DP * eps) &
+                       * (2.0_DP * SigByR12_shift / rcut_vdw &
+                       - SigByR6_shift / rcut_vdw)
            END IF
          ELSE IF (int_vdw_style(ibox) == vdw_mie) THEN
            eps = vdw_param1_table(itype,jtype)

--- a/Src/energy_routines.f90
+++ b/Src/energy_routines.f90
@@ -1274,17 +1274,25 @@ CONTAINS
                          SigByR2_shift = sig**2/rcut_vdwsq(ibox)
                          SigByR6_shift = SigByR2_shift * SigByR2_shift * SigByR2_shift
                          SigByR12_shift = SigByR6_shift * SigByR6_shift
-
+                         WRITE(*,*) "U_lj: ", Eij_vdw
                          Eij_vdw = Eij_vdw &
                                  - 4.0_DP * eps * (SigByR12_shift - SigByR6_shift)
 
+                         WRITE(*,*) "U_lj_potshift: ", Eij_vdw
                          rij = SQRT(rijsq)
                          rcut_vdw = SQRT(rcut_vdwsq(ibox))
+                         WRITE(*,*) "rij: ", rij 
+                         WRITE(*,*) "rcut: ", rcut_vdw
+                         WRITE(*,*) "eps: ", eps
+                         WRITE(*,*) "sig:", sig
+                         WRITE(*,*) "SigbyR12: ", SigByR12
+                         WRITE(*,*) "SigbyR6: ", SigByR6
 
                          dEij_dr = - 24.0_DP * eps * ( 2.0_DP * SigByR12_shift / rcut_vdw &
                                                       - SigByR6_shift / rcut_vdw )
 
                          Eij_vdw = Eij_vdw - (rij - rcut_vdw) * dEij_dr
+                         WRITE(*,*) "U_lj_forceshift: ", Eij_vdw
 
                    END IF
 

--- a/Src/global_variables.f90
+++ b/Src/global_variables.f90
@@ -108,7 +108,7 @@ USE Type_Definitions
   INTEGER, PARAMETER :: vdw_minimum = 5
   INTEGER, PARAMETER :: vdw_charmm = 6
   INTEGER, PARAMETER :: vdw_cut_switch = 7
-  INTEGER, PARAMETER :: vdw_cut_force_shift = 8
+  INTEGER, PARAMETER :: vdw_cut_shift_force = 8
   INTEGER, PARAMETER :: vdw_mie = 9
 
   INTEGER, PARAMETER :: charge_none = 0

--- a/Src/global_variables.f90
+++ b/Src/global_variables.f90
@@ -108,7 +108,8 @@ USE Type_Definitions
   INTEGER, PARAMETER :: vdw_minimum = 5
   INTEGER, PARAMETER :: vdw_charmm = 6
   INTEGER, PARAMETER :: vdw_cut_switch = 7
-  INTEGER, PARAMETER :: vdw_mie = 8
+  INTEGER, PARAMETER :: vdw_cut_force_shift = 8
+  INTEGER, PARAMETER :: vdw_mie = 9
 
   INTEGER, PARAMETER :: charge_none = 0
   INTEGER, PARAMETER :: charge_coul = 1

--- a/Src/input_routines.f90
+++ b/Src/input_routines.f90
@@ -476,8 +476,8 @@ SUBROUTINE Get_Pair_Style
                     rcut9(ibox) = rcut3(ibox) * rcut3(ibox) * rcut3(ibox)
                  ELSE IF (vdw_sum_style(ibox) == 'cut_shift') THEN
                     int_vdw_sum_style(ibox) = vdw_cut_shift
-                 ELSE IF (vdw_sum_style(ibox) == 'cut_force_shift') THEN
-                    int_vdw_sum_style(ibox) = vdw_cut_force_shift
+                 ELSE IF (vdw_sum_style(ibox) == 'cut_shift-force') THEN
+                    int_vdw_sum_style(ibox) = vdw_cut_shift_force
                  ELSE
                     err_msg = ''
                     err_msg(1) = 'Keyword ' // TRIM(line_array(2)) // ' on line number ' // &

--- a/Src/input_routines.f90
+++ b/Src/input_routines.f90
@@ -476,6 +476,8 @@ SUBROUTINE Get_Pair_Style
                     rcut9(ibox) = rcut3(ibox) * rcut3(ibox) * rcut3(ibox)
                  ELSE IF (vdw_sum_style(ibox) == 'cut_shift') THEN
                     int_vdw_sum_style(ibox) = vdw_cut_shift
+                 ELSE IF (vdw_sum_style(ibox) == 'cut_force_shift') THEN
+                    int_vdw_sum_style(ibox) = vdw_cut_force_shift
                  ELSE
                     err_msg = ''
                     err_msg(1) = 'Keyword ' // TRIM(line_array(2)) // ' on line number ' // &


### PR DESCRIPTION
## Description
Add support for the shifted force LJ potential:
`u_sf(r) = u_lj(r) - u_lj(r_cut) - (r - r_cut) * du_lj/dr(r_cut)`

where `r` is the distance between two particles, `u_lj` is the standard LJ potential, and `r_cut` is the cutoff distance. 

## How Has This Been Tested?
Confirmed that the total energy and pressure matches LAMMPS for a single pair of particles as well as a box with 5000 particles. 

## Backward Compatibility
Full backward compatibility is maintained. A new cutoff style, `cut_shift-force` is added.

## Post Submission Checklist

I still need to add documentation and a unit test. I will update the submission once those are completed. 

- [ ] Suitable new documentation files and/or updates to the existing docs are included.
- [ ] One or more example input decks are included.
