### PR TITLE
Initialize identity_switch trial counter to zero

### DIFF
--- a/Src/initialize.f90
+++ b/Src/initialize.f90
@@ -88,6 +88,7 @@ SUBROUTINE Initialize
   ntrials(:,:)%angle = 0
   ntrials(:,:)%insertion = 0
   ntrials(:,:)%deletion = 0
+  ntrials(:,:)%switch = 0
   ntrials(:,:)%disp_atom = 0
   ntrials(:,:)%cpcalc = 0
 


### PR DESCRIPTION
## Description
Initialize `ntrials()%switch` to 0. Even though `identity_switch` is not fully implemented and supported in the current version, this bug sometimes caused the log file to report that some number of ID switch trials were "attempted". No trials were actually attempted; the log file was reporting the uninitialized value of `ntrials()%switch`.

## Related Issue
Closes #57 

## How Has This Been Tested?
Local tests verify that the number of ID switch trials is no longer reported in the log file.