### PR TITLE
Expand maximum line length and number of items per line

### DIFF
--- a/Src/create_nonbond_table.f90
+++ b/Src/create_nonbond_table.f90
@@ -68,7 +68,7 @@
   !custom mixing rules
   INTEGER :: ierr,line_nbr,nbr_entries, is_1, is_2, ia_1, ia_2, itype_custom, jtype_custom
   INTEGER ::  i_type1, i_type2
-  CHARACTER(120) :: line_string, line_array(60)
+  CHARACTER(360) :: line_string, line_array(60)
 
 
 !******************************************************************************

--- a/Src/create_nonbond_table.f90
+++ b/Src/create_nonbond_table.f90
@@ -68,7 +68,7 @@
   !custom mixing rules
   INTEGER :: ierr,line_nbr,nbr_entries, is_1, is_2, ia_1, ia_2, itype_custom, jtype_custom
   INTEGER ::  i_type1, i_type2
-  CHARACTER(120) :: line_string, line_array(20)
+  CHARACTER(120) :: line_string, line_array(60)
 
 
 !******************************************************************************

--- a/Src/create_nonbond_table.f90
+++ b/Src/create_nonbond_table.f90
@@ -68,7 +68,7 @@
   !custom mixing rules
   INTEGER :: ierr,line_nbr,nbr_entries, is_1, is_2, ia_1, ia_2, itype_custom, jtype_custom
   INTEGER ::  i_type1, i_type2
-  CHARACTER(360) :: line_string, line_array(60)
+  CHARACTER(STRING_LEN) :: line_string, line_array(60)
 
 
 !******************************************************************************

--- a/Src/energy_routines.f90
+++ b/Src/energy_routines.f90
@@ -249,8 +249,6 @@ CONTAINS
        IF (bond_list(ib,is)%int_bond_type == int_none) THEN
           l0 = bond_list(ib,is)%bond_param(1)
           ltol = bond_list(ib,is)%bond_param(2)
-          WRITE(*,*) ltol
-          WRITE(*,*) l0
           CALL Get_Bond_Length(ib,im,is,length)
           IF (abs(l0 - length) > ltol) THEN
              WRITE(mcf_bond_length,'(F7.3)') l0

--- a/Src/energy_routines.f90
+++ b/Src/energy_routines.f90
@@ -249,6 +249,8 @@ CONTAINS
        IF (bond_list(ib,is)%int_bond_type == int_none) THEN
           l0 = bond_list(ib,is)%bond_param(1)
           ltol = bond_list(ib,is)%bond_param(2)
+          WRITE(*,*) ltol
+          WRITE(*,*) l0
           CALL Get_Bond_Length(ib,im,is,length)
           IF (abs(l0 - length) > ltol) THEN
              WRITE(mcf_bond_length,'(F7.3)') l0

--- a/Src/gcmc_control.f90
+++ b/Src/gcmc_control.f90
@@ -45,7 +45,7 @@ SUBROUTINE GCMC_Control
   IMPLICIT NONE
 
   INTEGER :: ierr,line_nbr,nbr_entries, i,j, ii,this_mol
-  CHARACTER(120) :: line_string, line_array(20)
+  CHARACTER(120) :: line_string, line_array(60)
   REAL(DP) :: e_total_bond, e_total_angle, e_total_intra_nb, e_total_inter_nb
   REAL(DP) ::  E_bond, E_angle, E_dihedral, E_improper
   REAL(DP) :: E_intra_vdw, E_intra_qq, E_inter_vdw, E_inter_qq, W_intra_vdw, W_intra_qq

--- a/Src/gcmc_control.f90
+++ b/Src/gcmc_control.f90
@@ -45,7 +45,7 @@ SUBROUTINE GCMC_Control
   IMPLICIT NONE
 
   INTEGER :: ierr,line_nbr,nbr_entries, i,j, ii,this_mol
-  CHARACTER(360) :: line_string, line_array(60)
+  CHARACTER(STRING_LEN) :: line_string, line_array(60)
   REAL(DP) :: e_total_bond, e_total_angle, e_total_intra_nb, e_total_inter_nb
   REAL(DP) ::  E_bond, E_angle, E_dihedral, E_improper
   REAL(DP) :: E_intra_vdw, E_intra_qq, E_inter_vdw, E_inter_qq, W_intra_vdw, W_intra_qq

--- a/Src/gcmc_control.f90
+++ b/Src/gcmc_control.f90
@@ -45,7 +45,7 @@ SUBROUTINE GCMC_Control
   IMPLICIT NONE
 
   INTEGER :: ierr,line_nbr,nbr_entries, i,j, ii,this_mol
-  CHARACTER(120) :: line_string, line_array(60)
+  CHARACTER(360) :: line_string, line_array(60)
   REAL(DP) :: e_total_bond, e_total_angle, e_total_intra_nb, e_total_inter_nb
   REAL(DP) ::  E_bond, E_angle, E_dihedral, E_improper
   REAL(DP) :: E_intra_vdw, E_intra_qq, E_inter_vdw, E_inter_qq, W_intra_vdw, W_intra_qq

--- a/Src/input_routines.f90
+++ b/Src/input_routines.f90
@@ -59,7 +59,7 @@ SUBROUTINE Get_Run_Name
 !******************************************************************************
 
   INTEGER :: ierr,line_nbr,nbr_entries
-  CHARACTER(120) :: line_string, line_array(60)
+  CHARACTER(360) :: line_string, line_array(60)
 
 
 !******************************************************************************
@@ -123,7 +123,7 @@ SUBROUTINE Get_Nspecies
 !******************************************************************************
 
   INTEGER :: ierr,line_nbr,nbr_entries, i
-  CHARACTER(120) :: line_string, line_array(60)
+  CHARACTER(360) :: line_string, line_array(60)
 !******************************************************************************
   WRITE(logunit,*)
   WRITE(logunit,'(A)') 'Number of species'
@@ -255,7 +255,7 @@ SUBROUTINE Get_Sim_Type
 ! ignored.
 !******************************************************************************
   INTEGER :: ierr,line_nbr,nbr_entries
-  CHARACTER(120) :: line_string, line_array(60)
+  CHARACTER(360) :: line_string, line_array(60)
 
 !******************************************************************************
   WRITE(logunit,*)
@@ -356,7 +356,7 @@ SUBROUTINE Get_Pair_Style
 !                 need to be stored.
 !******************************************************************************
   INTEGER :: ierr,line_nbr,nbr_entries, iassign, ibox, k
-  CHARACTER(120) :: line_string, line_array(60)
+  CHARACTER(360) :: line_string, line_array(60)
 
   REAL(DP), ALLOCATABLE :: ewald_tol(:)
 
@@ -879,7 +879,7 @@ SUBROUTINE Get_Mixing_Rules
 ! ignored. If no mixing rule is specified, Lorentz-Berthelot is used as default.
 !******************************************************************************
   INTEGER :: ierr,line_nbr,nbr_entries
-  CHARACTER(120) :: line_string, line_array(60)
+  CHARACTER(360) :: line_string, line_array(60)
 
 !******************************************************************************
   REWIND(inputunit)
@@ -952,7 +952,7 @@ SUBROUTINE Get_Molecule_Info
 
   INTEGER :: ierr,line_nbr,nbr_entries, i, openstatus, is, max_index, input_line_nbr
   INTEGER :: mcf_index(5), dummy
-  CHARACTER(120) :: line_string, line_array(60), source_dir
+  CHARACTER(360) :: line_string, line_array(60), source_dir
   LOGICAL :: l_source_dir
 
 !******************************************************************************
@@ -1360,7 +1360,7 @@ SUBROUTINE Get_Atom_Info(is)
   INTEGER, INTENT(IN) :: is
 
   INTEGER :: ierr,line_nbr,nbr_entries, ia
-  CHARACTER(120) :: line_string, line_array(60)
+  CHARACTER(360) :: line_string, line_array(60)
 
 !******************************************************************************
   REWIND(molfile_unit)
@@ -1613,7 +1613,7 @@ SUBROUTINE Get_Bond_Info(is)
   INTEGER, INTENT(IN) :: is
 
   INTEGER :: ierr,line_nbr,nbr_entries, ib
-  CHARACTER(120) :: line_string, line_array(60)
+  CHARACTER(360) :: line_string, line_array(60)
 
 !******************************************************************************
   REWIND(molfile_unit)
@@ -1683,7 +1683,6 @@ SUBROUTINE Get_Bond_Info(is)
               bond_list(ib,is)%int_bond_type = int_none
 
               bond_list(ib,is)%bond_param(1) = String_To_Double(line_array(5))
-              WRITE(*,*) "NBR ENTRIES:", nbr_entries
               IF (nbr_entries == 6) THEN
                  ! bond length tolerance given in MCF
                  bond_list(ib,is)%bond_param(2) = String_To_Double(line_array(6))
@@ -1759,7 +1758,7 @@ SUBROUTINE Get_Angle_Info(is)
   INTEGER, INTENT(IN) :: is
 
   INTEGER :: ierr,line_nbr,nbr_entries, iang, nangles_linear
-  CHARACTER(120) :: line_string, line_array(60)
+  CHARACTER(360) :: line_string, line_array(60)
 
 !******************************************************************************
   REWIND(molfile_unit)
@@ -1934,7 +1933,7 @@ SUBROUTINE Get_Dihedral_Info(is)
   INTEGER, INTENT(IN) :: is
 
   INTEGER :: ierr,line_nbr,nbr_entries, idihed
-  CHARACTER(120) :: line_string, line_array(60)
+  CHARACTER(360) :: line_string, line_array(60)
 
 !******************************************************************************
   REWIND(molfile_unit)
@@ -2164,7 +2163,7 @@ SUBROUTINE Get_Improper_Info(is)
 INTEGER, INTENT(IN) :: is
 
   INTEGER :: ierr,line_nbr,nbr_entries, iimprop
-  CHARACTER(120) :: line_string, line_array(60)
+  CHARACTER(360) :: line_string, line_array(60)
 
 !******************************************************************************
   REWIND(molfile_unit)
@@ -2328,7 +2327,7 @@ SUBROUTINE Get_Fragment_Anchor_Info(is)
 
   INTEGER :: i, line_nbr, ierr, min_entries, nbr_entries, ianchor
 
-  CHARACTER(120) :: line_String,line_array(60)
+  CHARACTER(360) :: line_String,line_array(60)
 
 !******************************************************************************
   WRITE(logunit,*)
@@ -2435,7 +2434,7 @@ SUBROUTINE Get_Fragment_Info(is)
   INTEGER :: nanchors, iatoms, jatoms, ibonds, iatoms_bond
   INTEGER :: i_atom, j_atom, atom1, atom2
   INTEGER, ALLOCATABLE :: anchor_id(:)
-  CHARACTER(120) :: line_string, line_array(60)
+  CHARACTER(360) :: line_string, line_array(60)
   !CHARACTER(50000) :: line_array_zeo(10000)
 
 !******************************************************************************
@@ -2670,7 +2669,7 @@ SUBROUTINE Get_Fragment_Connectivity_Info(is)
   INTEGER :: ierr, line_nbr, ifrag, nbr_entries, i, j, ifrag_connect, frag1, frag2
   INTEGER, ALLOCATABLE :: temp_frag(:)
 
-  CHARACTER(120) :: line_string,line_array(60)
+  CHARACTER(360) :: line_string,line_array(60)
 
   ! Variables for determing prob_del1
   INTEGER :: natoms_del_with_frag1, natoms_del_with_frag2
@@ -2937,7 +2936,7 @@ SUBROUTINE Get_Fragment_File_Info(is)
 
   INTEGER :: ierr, line_nbr, i, j, ifrag, nbr_entries, is
   REAL(DP) :: vdw_cutoff, coul_cutoff
-  CHARACTER(120) :: line_string, line_array(60), source_dir
+  CHARACTER(360) :: line_string, line_array(60), source_dir
   CHARACTER(4) :: ring_flag
   LOGICAL :: l_source_dir
 
@@ -3296,7 +3295,7 @@ END SUBROUTINE Get_Fragment_Coords
 SUBROUTINE Get_Intra_Scaling(is)
 !******************************************************************************
   INTEGER :: ierr,line_nbr,nbr_entries, iimprop, is, i
-  CHARACTER(120) :: line_string, line_array(60)
+  CHARACTER(360) :: line_string, line_array(60)
   LOGICAL :: l_intra_scaling_mcf
 
 !******************************************************************************
@@ -3487,7 +3486,7 @@ SUBROUTINE Get_Box_Info
 !   cubic, orthogonal, cell_metrix
 !******************************************************************************
   INTEGER :: ierr,line_nbr,nbr_entries,ibox, is
-  CHARACTER(120) :: line_string, line_array(60)
+  CHARACTER(360) :: line_string, line_array(60)
   REAL(DP) :: radius, zmax, zmin
 
 !******************************************************************************
@@ -3823,7 +3822,7 @@ SUBROUTINE Get_Temperature_Info
   IMPLICIT NONE
 
   INTEGER :: ierr, line_nbr, i, nbr_entries
-  CHARACTER(120) :: line_string, line_array(60)
+  CHARACTER(360) :: line_string, line_array(60)
 
 !******************************************************************************
   WRITE(logunit,*)
@@ -3904,7 +3903,7 @@ SUBROUTINE Get_Pressure_Info
 !******************************************************************************
 
   INTEGER :: ierr, line_nbr, nbr_entries, i
-  CHARACTER(120) :: line_string, line_array(60)
+  CHARACTER(360) :: line_string, line_array(60)
 
 !******************************************************************************
   WRITE(logunit,*)
@@ -3984,7 +3983,7 @@ SUBROUTINE Get_Chemical_Potential_Info
   IMPLICIT NONE
 
   INTEGER :: line_nbr, nbr_entries, ierr, is, spec_counter, ibox
-  CHARACTER(120) :: line_string, line_array(60)
+  CHARACTER(360) :: line_string, line_array(60)
 
 !******************************************************************************
   REWIND(inputunit)
@@ -4089,7 +4088,7 @@ SUBROUTINE Get_Move_Probabilities
 
   INTEGER :: ierr, nbr_entries, line_nbr, i, j, ibox, is, vol_int
   INTEGER ::  kbox, this_box, first_species, second_species
-  CHARACTER(120) :: line_string, line_array(60), line_string2
+  CHARACTER(360) :: line_string, line_array(60), line_string2
   CHARACTER(4) :: Symbol
   !INTEGER, DIMENSION(:,:), ALLOCATABLE :: swap_list
 
@@ -4770,7 +4769,7 @@ SUBROUTINE Get_Start_Type
 !******************************************************************************
 
   INTEGER :: ierr, line_nbr, nbr_entries, i,j, ibox, is
-  CHARACTER(120) :: line_string, line_array(60)
+  CHARACTER(360) :: line_string, line_array(60)
   CHARACTER(1) :: first_character
   CHARACTER(4) :: symbol
 
@@ -5053,7 +5052,7 @@ SUBROUTINE Get_Run_Type
   IMPLICIT NONE
 
   INTEGER :: ierr, line_nbr, nbr_entries,i, ia
-  CHARACTER(120) :: line_string,line_array(60)
+  CHARACTER(360) :: line_string,line_array(60)
   LOGICAL :: overlap
 
 !******************************************************************************
@@ -5179,7 +5178,7 @@ SUBROUTINE Get_CBMC_Info
 
   INTEGER :: ibox, is
   INTEGER :: ierr, line_nbr, nbr_entries
-  CHARACTER(120) :: line_string,line_array(60)
+  CHARACTER(360) :: line_string,line_array(60)
   LOGICAL :: need_kappa_ins, need_kappa_dih
 
 !******************************************************************************
@@ -5339,7 +5338,7 @@ SUBROUTINE Get_Seed_Info
 !******************************************************************************
 
   INTEGER :: ierr, line_nbr, nbr_entries
-  CHARACTER(120) :: line_string,line_array(60)
+  CHARACTER(360) :: line_string,line_array(60)
 
 !******************************************************************************
   WRITE(logunit,*)
@@ -5404,7 +5403,7 @@ SUBROUTINE Get_Simulation_Length_Info
 !******************************************************************************
 
   INTEGER :: ierr, line_nbr, nbr_entries, ibox
-  CHARACTER(120) :: line_string, line_array(60)
+  CHARACTER(360) :: line_string, line_array(60)
   LOGICAL :: l_run
 
 !******************************************************************************
@@ -5695,7 +5694,7 @@ USE Global_Variables, ONLY: cpcollect
 
   INTEGER :: ierr, line_nbr, nbr_properties, max_properties, nbr_entries
   INTEGER :: i, j, this_box, ibox, is, average_id, ifrac
-  CHARACTER(120) :: line_string, line_array(60)
+  CHARACTER(360) :: line_string, line_array(60)
   CHARACTER(12) :: extension
   CHARACTER(9) :: extension1
   CHARACTER(17) :: extension2
@@ -6078,7 +6077,7 @@ SUBROUTINE Copy_Inputfile
 !******************************************************************************
 
   INTEGER :: ierr, line_nbr, line_inputfile_start
-  CHARACTER(120) :: line_string
+  CHARACTER(360) :: line_string
   LOGICAL :: input_startcopy
 
   WRITE(logunit,*)
@@ -6164,7 +6163,7 @@ SUBROUTINE Get_Rcutoff_Low
 !******************************************************************************
 
   INTEGER :: ierr, line_nbr, nbr_entries
-  CHARACTER(120) :: line_string, line_array(60)
+  CHARACTER(360) :: line_string, line_array(60)
 
 !******************************************************************************
   WRITE(logunit,*)
@@ -6225,7 +6224,7 @@ SUBROUTINE Get_File_Info
 
   INTEGER :: ierr, nbr_entries, line_nbr, is
 
-  CHARACTER(120) :: line_array(60), line_string
+  CHARACTER(360) :: line_array(60), line_string
 
 !******************************************************************************
   WRITE(logunit,*)
@@ -6290,7 +6289,7 @@ SUBROUTINE Get_Lattice_File_Info
     IMPLICIT NONE
 
     INTEGER :: line_nbr, ierr, nbr_entries
-    CHARACTER*120 :: line_string, line_array(60)
+    CHARACTER(360) :: line_string, line_array(60)
 
 !******************************************************************************
     WRITE(logunit,*)
@@ -6451,7 +6450,7 @@ SUBROUTINE Get_Verbosity_Info
 !******************************************************************************
 
   INTEGER :: ierr,line_nbr,nbr_entries
-  CHARACTER(120) :: line_string, line_array(60)
+  CHARACTER(360) :: line_string, line_array(60)
 
 !******************************************************************************
   WRITE(logunit,*)

--- a/Src/input_routines.f90
+++ b/Src/input_routines.f90
@@ -59,7 +59,7 @@ SUBROUTINE Get_Run_Name
 !******************************************************************************
 
   INTEGER :: ierr,line_nbr,nbr_entries
-  CHARACTER(360) :: line_string, line_array(60)
+  CHARACTER(STRING_LEN) :: line_string, line_array(60)
 
 
 !******************************************************************************
@@ -123,7 +123,7 @@ SUBROUTINE Get_Nspecies
 !******************************************************************************
 
   INTEGER :: ierr,line_nbr,nbr_entries, i
-  CHARACTER(360) :: line_string, line_array(60)
+  CHARACTER(STRING_LEN) :: line_string, line_array(60)
 !******************************************************************************
   WRITE(logunit,*)
   WRITE(logunit,'(A)') 'Number of species'
@@ -255,7 +255,7 @@ SUBROUTINE Get_Sim_Type
 ! ignored.
 !******************************************************************************
   INTEGER :: ierr,line_nbr,nbr_entries
-  CHARACTER(360) :: line_string, line_array(60)
+  CHARACTER(STRING_LEN) :: line_string, line_array(60)
 
 !******************************************************************************
   WRITE(logunit,*)
@@ -356,7 +356,7 @@ SUBROUTINE Get_Pair_Style
 !                 need to be stored.
 !******************************************************************************
   INTEGER :: ierr,line_nbr,nbr_entries, iassign, ibox, k
-  CHARACTER(360) :: line_string, line_array(60)
+  CHARACTER(STRING_LEN) :: line_string, line_array(60)
 
   REAL(DP), ALLOCATABLE :: ewald_tol(:)
 
@@ -879,7 +879,7 @@ SUBROUTINE Get_Mixing_Rules
 ! ignored. If no mixing rule is specified, Lorentz-Berthelot is used as default.
 !******************************************************************************
   INTEGER :: ierr,line_nbr,nbr_entries
-  CHARACTER(360) :: line_string, line_array(60)
+  CHARACTER(STRING_LEN) :: line_string, line_array(60)
 
 !******************************************************************************
   REWIND(inputunit)
@@ -952,7 +952,7 @@ SUBROUTINE Get_Molecule_Info
 
   INTEGER :: ierr,line_nbr,nbr_entries, i, openstatus, is, max_index, input_line_nbr
   INTEGER :: mcf_index(5), dummy
-  CHARACTER(360) :: line_string, line_array(60), source_dir
+  CHARACTER(STRING_LEN) :: line_string, line_array(60), source_dir
   LOGICAL :: l_source_dir
 
 !******************************************************************************
@@ -1360,7 +1360,7 @@ SUBROUTINE Get_Atom_Info(is)
   INTEGER, INTENT(IN) :: is
 
   INTEGER :: ierr,line_nbr,nbr_entries, ia
-  CHARACTER(360) :: line_string, line_array(60)
+  CHARACTER(STRING_LEN) :: line_string, line_array(60)
 
 !******************************************************************************
   REWIND(molfile_unit)
@@ -1613,7 +1613,7 @@ SUBROUTINE Get_Bond_Info(is)
   INTEGER, INTENT(IN) :: is
 
   INTEGER :: ierr,line_nbr,nbr_entries, ib
-  CHARACTER(360) :: line_string, line_array(60)
+  CHARACTER(STRING_LEN) :: line_string, line_array(60)
 
 !******************************************************************************
   REWIND(molfile_unit)
@@ -1758,7 +1758,7 @@ SUBROUTINE Get_Angle_Info(is)
   INTEGER, INTENT(IN) :: is
 
   INTEGER :: ierr,line_nbr,nbr_entries, iang, nangles_linear
-  CHARACTER(360) :: line_string, line_array(60)
+  CHARACTER(STRING_LEN) :: line_string, line_array(60)
 
 !******************************************************************************
   REWIND(molfile_unit)
@@ -1933,7 +1933,7 @@ SUBROUTINE Get_Dihedral_Info(is)
   INTEGER, INTENT(IN) :: is
 
   INTEGER :: ierr,line_nbr,nbr_entries, idihed
-  CHARACTER(360) :: line_string, line_array(60)
+  CHARACTER(STRING_LEN) :: line_string, line_array(60)
 
 !******************************************************************************
   REWIND(molfile_unit)
@@ -2163,7 +2163,7 @@ SUBROUTINE Get_Improper_Info(is)
 INTEGER, INTENT(IN) :: is
 
   INTEGER :: ierr,line_nbr,nbr_entries, iimprop
-  CHARACTER(360) :: line_string, line_array(60)
+  CHARACTER(STRING_LEN) :: line_string, line_array(60)
 
 !******************************************************************************
   REWIND(molfile_unit)
@@ -2327,7 +2327,7 @@ SUBROUTINE Get_Fragment_Anchor_Info(is)
 
   INTEGER :: i, line_nbr, ierr, min_entries, nbr_entries, ianchor
 
-  CHARACTER(360) :: line_String,line_array(60)
+  CHARACTER(STRING_LEN) :: line_String,line_array(60)
 
 !******************************************************************************
   WRITE(logunit,*)
@@ -2434,7 +2434,7 @@ SUBROUTINE Get_Fragment_Info(is)
   INTEGER :: nanchors, iatoms, jatoms, ibonds, iatoms_bond
   INTEGER :: i_atom, j_atom, atom1, atom2
   INTEGER, ALLOCATABLE :: anchor_id(:)
-  CHARACTER(360) :: line_string, line_array(60)
+  CHARACTER(STRING_LEN) :: line_string, line_array(60)
   !CHARACTER(50000) :: line_array_zeo(10000)
 
 !******************************************************************************
@@ -2669,7 +2669,7 @@ SUBROUTINE Get_Fragment_Connectivity_Info(is)
   INTEGER :: ierr, line_nbr, ifrag, nbr_entries, i, j, ifrag_connect, frag1, frag2
   INTEGER, ALLOCATABLE :: temp_frag(:)
 
-  CHARACTER(360) :: line_string,line_array(60)
+  CHARACTER(STRING_LEN) :: line_string,line_array(60)
 
   ! Variables for determing prob_del1
   INTEGER :: natoms_del_with_frag1, natoms_del_with_frag2
@@ -2936,7 +2936,7 @@ SUBROUTINE Get_Fragment_File_Info(is)
 
   INTEGER :: ierr, line_nbr, i, j, ifrag, nbr_entries, is
   REAL(DP) :: vdw_cutoff, coul_cutoff
-  CHARACTER(360) :: line_string, line_array(60), source_dir
+  CHARACTER(STRING_LEN) :: line_string, line_array(60), source_dir
   CHARACTER(4) :: ring_flag
   LOGICAL :: l_source_dir
 
@@ -3295,7 +3295,7 @@ END SUBROUTINE Get_Fragment_Coords
 SUBROUTINE Get_Intra_Scaling(is)
 !******************************************************************************
   INTEGER :: ierr,line_nbr,nbr_entries, iimprop, is, i
-  CHARACTER(360) :: line_string, line_array(60)
+  CHARACTER(STRING_LEN) :: line_string, line_array(60)
   LOGICAL :: l_intra_scaling_mcf
 
 !******************************************************************************
@@ -3486,7 +3486,7 @@ SUBROUTINE Get_Box_Info
 !   cubic, orthogonal, cell_metrix
 !******************************************************************************
   INTEGER :: ierr,line_nbr,nbr_entries,ibox, is
-  CHARACTER(360) :: line_string, line_array(60)
+  CHARACTER(STRING_LEN) :: line_string, line_array(60)
   REAL(DP) :: radius, zmax, zmin
 
 !******************************************************************************
@@ -3822,7 +3822,7 @@ SUBROUTINE Get_Temperature_Info
   IMPLICIT NONE
 
   INTEGER :: ierr, line_nbr, i, nbr_entries
-  CHARACTER(360) :: line_string, line_array(60)
+  CHARACTER(STRING_LEN) :: line_string, line_array(60)
 
 !******************************************************************************
   WRITE(logunit,*)
@@ -3903,7 +3903,7 @@ SUBROUTINE Get_Pressure_Info
 !******************************************************************************
 
   INTEGER :: ierr, line_nbr, nbr_entries, i
-  CHARACTER(360) :: line_string, line_array(60)
+  CHARACTER(STRING_LEN) :: line_string, line_array(60)
 
 !******************************************************************************
   WRITE(logunit,*)
@@ -3983,7 +3983,7 @@ SUBROUTINE Get_Chemical_Potential_Info
   IMPLICIT NONE
 
   INTEGER :: line_nbr, nbr_entries, ierr, is, spec_counter, ibox
-  CHARACTER(360) :: line_string, line_array(60)
+  CHARACTER(STRING_LEN) :: line_string, line_array(60)
 
 !******************************************************************************
   REWIND(inputunit)
@@ -4088,7 +4088,7 @@ SUBROUTINE Get_Move_Probabilities
 
   INTEGER :: ierr, nbr_entries, line_nbr, i, j, ibox, is, vol_int
   INTEGER ::  kbox, this_box, first_species, second_species
-  CHARACTER(360) :: line_string, line_array(60), line_string2
+  CHARACTER(STRING_LEN) :: line_string, line_array(60), line_string2
   CHARACTER(4) :: Symbol
   !INTEGER, DIMENSION(:,:), ALLOCATABLE :: swap_list
 
@@ -4769,7 +4769,7 @@ SUBROUTINE Get_Start_Type
 !******************************************************************************
 
   INTEGER :: ierr, line_nbr, nbr_entries, i,j, ibox, is
-  CHARACTER(360) :: line_string, line_array(60)
+  CHARACTER(STRING_LEN) :: line_string, line_array(60)
   CHARACTER(1) :: first_character
   CHARACTER(4) :: symbol
 
@@ -5052,7 +5052,7 @@ SUBROUTINE Get_Run_Type
   IMPLICIT NONE
 
   INTEGER :: ierr, line_nbr, nbr_entries,i, ia
-  CHARACTER(360) :: line_string,line_array(60)
+  CHARACTER(STRING_LEN) :: line_string,line_array(60)
   LOGICAL :: overlap
 
 !******************************************************************************
@@ -5178,7 +5178,7 @@ SUBROUTINE Get_CBMC_Info
 
   INTEGER :: ibox, is
   INTEGER :: ierr, line_nbr, nbr_entries
-  CHARACTER(360) :: line_string,line_array(60)
+  CHARACTER(STRING_LEN) :: line_string,line_array(60)
   LOGICAL :: need_kappa_ins, need_kappa_dih
 
 !******************************************************************************
@@ -5338,7 +5338,7 @@ SUBROUTINE Get_Seed_Info
 !******************************************************************************
 
   INTEGER :: ierr, line_nbr, nbr_entries
-  CHARACTER(360) :: line_string,line_array(60)
+  CHARACTER(STRING_LEN) :: line_string,line_array(60)
 
 !******************************************************************************
   WRITE(logunit,*)
@@ -5403,7 +5403,7 @@ SUBROUTINE Get_Simulation_Length_Info
 !******************************************************************************
 
   INTEGER :: ierr, line_nbr, nbr_entries, ibox
-  CHARACTER(360) :: line_string, line_array(60)
+  CHARACTER(STRING_LEN) :: line_string, line_array(60)
   LOGICAL :: l_run
 
 !******************************************************************************
@@ -5694,7 +5694,7 @@ USE Global_Variables, ONLY: cpcollect
 
   INTEGER :: ierr, line_nbr, nbr_properties, max_properties, nbr_entries
   INTEGER :: i, j, this_box, ibox, is, average_id, ifrac
-  CHARACTER(360) :: line_string, line_array(60)
+  CHARACTER(STRING_LEN) :: line_string, line_array(60)
   CHARACTER(12) :: extension
   CHARACTER(9) :: extension1
   CHARACTER(17) :: extension2
@@ -6077,7 +6077,7 @@ SUBROUTINE Copy_Inputfile
 !******************************************************************************
 
   INTEGER :: ierr, line_nbr, line_inputfile_start
-  CHARACTER(360) :: line_string
+  CHARACTER(STRING_LEN) :: line_string
   LOGICAL :: input_startcopy
 
   WRITE(logunit,*)
@@ -6163,7 +6163,7 @@ SUBROUTINE Get_Rcutoff_Low
 !******************************************************************************
 
   INTEGER :: ierr, line_nbr, nbr_entries
-  CHARACTER(360) :: line_string, line_array(60)
+  CHARACTER(STRING_LEN) :: line_string, line_array(60)
 
 !******************************************************************************
   WRITE(logunit,*)
@@ -6224,7 +6224,7 @@ SUBROUTINE Get_File_Info
 
   INTEGER :: ierr, nbr_entries, line_nbr, is
 
-  CHARACTER(360) :: line_array(60), line_string
+  CHARACTER(STRING_LEN) :: line_array(60), line_string
 
 !******************************************************************************
   WRITE(logunit,*)
@@ -6289,7 +6289,7 @@ SUBROUTINE Get_Lattice_File_Info
     IMPLICIT NONE
 
     INTEGER :: line_nbr, ierr, nbr_entries
-    CHARACTER(360) :: line_string, line_array(60)
+    CHARACTER(STRING_LEN) :: line_string, line_array(60)
 
 !******************************************************************************
     WRITE(logunit,*)
@@ -6450,7 +6450,7 @@ SUBROUTINE Get_Verbosity_Info
 !******************************************************************************
 
   INTEGER :: ierr,line_nbr,nbr_entries
-  CHARACTER(360) :: line_string, line_array(60)
+  CHARACTER(STRING_LEN) :: line_string, line_array(60)
 
 !******************************************************************************
   WRITE(logunit,*)

--- a/Src/input_routines.f90
+++ b/Src/input_routines.f90
@@ -59,7 +59,7 @@ SUBROUTINE Get_Run_Name
 !******************************************************************************
 
   INTEGER :: ierr,line_nbr,nbr_entries
-  CHARACTER(120) :: line_string, line_array(20)
+  CHARACTER(120) :: line_string, line_array(60)
 
 
 !******************************************************************************
@@ -123,7 +123,7 @@ SUBROUTINE Get_Nspecies
 !******************************************************************************
 
   INTEGER :: ierr,line_nbr,nbr_entries, i
-  CHARACTER(120) :: line_string, line_array(20)
+  CHARACTER(120) :: line_string, line_array(60)
 !******************************************************************************
   WRITE(logunit,*)
   WRITE(logunit,'(A)') 'Number of species'
@@ -255,7 +255,7 @@ SUBROUTINE Get_Sim_Type
 ! ignored.
 !******************************************************************************
   INTEGER :: ierr,line_nbr,nbr_entries
-  CHARACTER(120) :: line_string, line_array(20)
+  CHARACTER(120) :: line_string, line_array(60)
 
 !******************************************************************************
   WRITE(logunit,*)
@@ -356,7 +356,7 @@ SUBROUTINE Get_Pair_Style
 !                 need to be stored.
 !******************************************************************************
   INTEGER :: ierr,line_nbr,nbr_entries, iassign, ibox, k
-  CHARACTER(120) :: line_string, line_array(20)
+  CHARACTER(120) :: line_string, line_array(60)
 
   REAL(DP), ALLOCATABLE :: ewald_tol(:)
 
@@ -879,7 +879,7 @@ SUBROUTINE Get_Mixing_Rules
 ! ignored. If no mixing rule is specified, Lorentz-Berthelot is used as default.
 !******************************************************************************
   INTEGER :: ierr,line_nbr,nbr_entries
-  CHARACTER(120) :: line_string, line_array(20)
+  CHARACTER(120) :: line_string, line_array(60)
 
 !******************************************************************************
   REWIND(inputunit)
@@ -952,7 +952,7 @@ SUBROUTINE Get_Molecule_Info
 
   INTEGER :: ierr,line_nbr,nbr_entries, i, openstatus, is, max_index, input_line_nbr
   INTEGER :: mcf_index(5), dummy
-  CHARACTER(120) :: line_string, line_array(20), source_dir
+  CHARACTER(120) :: line_string, line_array(60), source_dir
   LOGICAL :: l_source_dir
 
 !******************************************************************************
@@ -1360,7 +1360,7 @@ SUBROUTINE Get_Atom_Info(is)
   INTEGER, INTENT(IN) :: is
 
   INTEGER :: ierr,line_nbr,nbr_entries, ia
-  CHARACTER(120) :: line_string, line_array(20)
+  CHARACTER(120) :: line_string, line_array(60)
 
 !******************************************************************************
   REWIND(molfile_unit)
@@ -1613,7 +1613,7 @@ SUBROUTINE Get_Bond_Info(is)
   INTEGER, INTENT(IN) :: is
 
   INTEGER :: ierr,line_nbr,nbr_entries, ib
-  CHARACTER(120) :: line_string, line_array(20)
+  CHARACTER(120) :: line_string, line_array(60)
 
 !******************************************************************************
   REWIND(molfile_unit)
@@ -1683,6 +1683,7 @@ SUBROUTINE Get_Bond_Info(is)
               bond_list(ib,is)%int_bond_type = int_none
 
               bond_list(ib,is)%bond_param(1) = String_To_Double(line_array(5))
+              WRITE(*,*) "NBR ENTRIES:", nbr_entries
               IF (nbr_entries == 6) THEN
                  ! bond length tolerance given in MCF
                  bond_list(ib,is)%bond_param(2) = String_To_Double(line_array(6))
@@ -1758,7 +1759,7 @@ SUBROUTINE Get_Angle_Info(is)
   INTEGER, INTENT(IN) :: is
 
   INTEGER :: ierr,line_nbr,nbr_entries, iang, nangles_linear
-  CHARACTER(120) :: line_string, line_array(20)
+  CHARACTER(120) :: line_string, line_array(60)
 
 !******************************************************************************
   REWIND(molfile_unit)
@@ -1933,7 +1934,7 @@ SUBROUTINE Get_Dihedral_Info(is)
   INTEGER, INTENT(IN) :: is
 
   INTEGER :: ierr,line_nbr,nbr_entries, idihed
-  CHARACTER(120) :: line_string, line_array(20)
+  CHARACTER(120) :: line_string, line_array(60)
 
 !******************************************************************************
   REWIND(molfile_unit)
@@ -2163,7 +2164,7 @@ SUBROUTINE Get_Improper_Info(is)
 INTEGER, INTENT(IN) :: is
 
   INTEGER :: ierr,line_nbr,nbr_entries, iimprop
-  CHARACTER(120) :: line_string, line_array(20)
+  CHARACTER(120) :: line_string, line_array(60)
 
 !******************************************************************************
   REWIND(molfile_unit)
@@ -2327,7 +2328,7 @@ SUBROUTINE Get_Fragment_Anchor_Info(is)
 
   INTEGER :: i, line_nbr, ierr, min_entries, nbr_entries, ianchor
 
-  CHARACTER(120) :: line_String,line_array(20)
+  CHARACTER(120) :: line_String,line_array(60)
 
 !******************************************************************************
   WRITE(logunit,*)
@@ -2434,7 +2435,7 @@ SUBROUTINE Get_Fragment_Info(is)
   INTEGER :: nanchors, iatoms, jatoms, ibonds, iatoms_bond
   INTEGER :: i_atom, j_atom, atom1, atom2
   INTEGER, ALLOCATABLE :: anchor_id(:)
-  CHARACTER(120) :: line_string, line_array(20)
+  CHARACTER(120) :: line_string, line_array(60)
   !CHARACTER(50000) :: line_array_zeo(10000)
 
 !******************************************************************************
@@ -2669,7 +2670,7 @@ SUBROUTINE Get_Fragment_Connectivity_Info(is)
   INTEGER :: ierr, line_nbr, ifrag, nbr_entries, i, j, ifrag_connect, frag1, frag2
   INTEGER, ALLOCATABLE :: temp_frag(:)
 
-  CHARACTER(120) :: line_string,line_array(20)
+  CHARACTER(120) :: line_string,line_array(60)
 
   ! Variables for determing prob_del1
   INTEGER :: natoms_del_with_frag1, natoms_del_with_frag2
@@ -2936,7 +2937,7 @@ SUBROUTINE Get_Fragment_File_Info(is)
 
   INTEGER :: ierr, line_nbr, i, j, ifrag, nbr_entries, is
   REAL(DP) :: vdw_cutoff, coul_cutoff
-  CHARACTER(120) :: line_string, line_array(20), source_dir
+  CHARACTER(120) :: line_string, line_array(60), source_dir
   CHARACTER(4) :: ring_flag
   LOGICAL :: l_source_dir
 
@@ -3295,7 +3296,7 @@ END SUBROUTINE Get_Fragment_Coords
 SUBROUTINE Get_Intra_Scaling(is)
 !******************************************************************************
   INTEGER :: ierr,line_nbr,nbr_entries, iimprop, is, i
-  CHARACTER(120) :: line_string, line_array(20)
+  CHARACTER(120) :: line_string, line_array(60)
   LOGICAL :: l_intra_scaling_mcf
 
 !******************************************************************************
@@ -3486,7 +3487,7 @@ SUBROUTINE Get_Box_Info
 !   cubic, orthogonal, cell_metrix
 !******************************************************************************
   INTEGER :: ierr,line_nbr,nbr_entries,ibox, is
-  CHARACTER(120) :: line_string, line_array(20)
+  CHARACTER(120) :: line_string, line_array(60)
   REAL(DP) :: radius, zmax, zmin
 
 !******************************************************************************
@@ -3822,7 +3823,7 @@ SUBROUTINE Get_Temperature_Info
   IMPLICIT NONE
 
   INTEGER :: ierr, line_nbr, i, nbr_entries
-  CHARACTER(120) :: line_string, line_array(20)
+  CHARACTER(120) :: line_string, line_array(60)
 
 !******************************************************************************
   WRITE(logunit,*)
@@ -3903,7 +3904,7 @@ SUBROUTINE Get_Pressure_Info
 !******************************************************************************
 
   INTEGER :: ierr, line_nbr, nbr_entries, i
-  CHARACTER(120) :: line_string, line_array(20)
+  CHARACTER(120) :: line_string, line_array(60)
 
 !******************************************************************************
   WRITE(logunit,*)
@@ -3983,7 +3984,7 @@ SUBROUTINE Get_Chemical_Potential_Info
   IMPLICIT NONE
 
   INTEGER :: line_nbr, nbr_entries, ierr, is, spec_counter, ibox
-  CHARACTER(120) :: line_string, line_array(20)
+  CHARACTER(120) :: line_string, line_array(60)
 
 !******************************************************************************
   REWIND(inputunit)
@@ -4088,7 +4089,7 @@ SUBROUTINE Get_Move_Probabilities
 
   INTEGER :: ierr, nbr_entries, line_nbr, i, j, ibox, is, vol_int
   INTEGER ::  kbox, this_box, first_species, second_species
-  CHARACTER(120) :: line_string, line_array(30), line_string2
+  CHARACTER(120) :: line_string, line_array(60), line_string2
   CHARACTER(4) :: Symbol
   !INTEGER, DIMENSION(:,:), ALLOCATABLE :: swap_list
 
@@ -4769,7 +4770,7 @@ SUBROUTINE Get_Start_Type
 !******************************************************************************
 
   INTEGER :: ierr, line_nbr, nbr_entries, i,j, ibox, is
-  CHARACTER(120) :: line_string, line_array(20)
+  CHARACTER(120) :: line_string, line_array(60)
   CHARACTER(1) :: first_character
   CHARACTER(4) :: symbol
 
@@ -5052,7 +5053,7 @@ SUBROUTINE Get_Run_Type
   IMPLICIT NONE
 
   INTEGER :: ierr, line_nbr, nbr_entries,i, ia
-  CHARACTER(120) :: line_string,line_array(20)
+  CHARACTER(120) :: line_string,line_array(60)
   LOGICAL :: overlap
 
 !******************************************************************************
@@ -5178,7 +5179,7 @@ SUBROUTINE Get_CBMC_Info
 
   INTEGER :: ibox, is
   INTEGER :: ierr, line_nbr, nbr_entries
-  CHARACTER(120) :: line_string,line_array(30)
+  CHARACTER(120) :: line_string,line_array(60)
   LOGICAL :: need_kappa_ins, need_kappa_dih
 
 !******************************************************************************
@@ -5338,7 +5339,7 @@ SUBROUTINE Get_Seed_Info
 !******************************************************************************
 
   INTEGER :: ierr, line_nbr, nbr_entries
-  CHARACTER(120) :: line_string,line_array(20)
+  CHARACTER(120) :: line_string,line_array(60)
 
 !******************************************************************************
   WRITE(logunit,*)
@@ -5403,7 +5404,7 @@ SUBROUTINE Get_Simulation_Length_Info
 !******************************************************************************
 
   INTEGER :: ierr, line_nbr, nbr_entries, ibox
-  CHARACTER(120) :: line_string, line_array(20)
+  CHARACTER(120) :: line_string, line_array(60)
   LOGICAL :: l_run
 
 !******************************************************************************
@@ -5694,7 +5695,7 @@ USE Global_Variables, ONLY: cpcollect
 
   INTEGER :: ierr, line_nbr, nbr_properties, max_properties, nbr_entries
   INTEGER :: i, j, this_box, ibox, is, average_id, ifrac
-  CHARACTER(120) :: line_string, line_array(20)
+  CHARACTER(120) :: line_string, line_array(60)
   CHARACTER(12) :: extension
   CHARACTER(9) :: extension1
   CHARACTER(17) :: extension2
@@ -6163,7 +6164,7 @@ SUBROUTINE Get_Rcutoff_Low
 !******************************************************************************
 
   INTEGER :: ierr, line_nbr, nbr_entries
-  CHARACTER(120) :: line_string, line_array(20)
+  CHARACTER(120) :: line_string, line_array(60)
 
 !******************************************************************************
   WRITE(logunit,*)
@@ -6224,7 +6225,7 @@ SUBROUTINE Get_File_Info
 
   INTEGER :: ierr, nbr_entries, line_nbr, is
 
-  CHARACTER(120) :: line_array(20), line_string
+  CHARACTER(120) :: line_array(60), line_string
 
 !******************************************************************************
   WRITE(logunit,*)
@@ -6289,7 +6290,7 @@ SUBROUTINE Get_Lattice_File_Info
     IMPLICIT NONE
 
     INTEGER :: line_nbr, ierr, nbr_entries
-    CHARACTER*120 :: line_string, line_array(20)
+    CHARACTER*120 :: line_string, line_array(60)
 
 !******************************************************************************
     WRITE(logunit,*)
@@ -6450,7 +6451,7 @@ SUBROUTINE Get_Verbosity_Info
 !******************************************************************************
 
   INTEGER :: ierr,line_nbr,nbr_entries
-  CHARACTER(120) :: line_string, line_array(20)
+  CHARACTER(120) :: line_string, line_array(60)
 
 !******************************************************************************
   WRITE(logunit,*)

--- a/Src/io_utilities.f90
+++ b/Src/io_utilities.f90
@@ -54,8 +54,11 @@ MODULE IO_Utilities
   !    12/10/13  : Beta version
   !********************************************************************************
   USE Global_Variables
+  USE File_Names
 
   IMPLICIT NONE
+
+  INTEGER, PARAMETER :: STRING_LEN = 360
 
 CONTAINS
 
@@ -68,7 +71,7 @@ CONTAINS
 !********************************************************************************
     INTEGER, INTENT(IN) :: file_number
     INTEGER, INTENT(OUT) :: ierr
-    CHARACTER(360), INTENT(OUT) :: string
+    CHARACTER(STRING_LEN), INTENT(OUT) :: string
 !********************************************************************************
 
     READ(file_number,'(A360)',IOSTAT=ierr) string
@@ -86,12 +89,12 @@ CONTAINS
 ! different by detecting a space between entries. It also tests to see if the 
 ! minimum number of entries specified was met or not. If not, and error is returned.
 !********************************************************************************
-    CHARACTER(360), INTENT(OUT) :: line_array(60)
+    CHARACTER(STRING_LEN), INTENT(OUT) :: line_array(60)
     INTEGER, INTENT(IN) :: file_number,min_entries,line_nbr
     INTEGER, INTENT(OUT) :: nbr_entries
     INTEGER, INTENT(INOUT) :: ierr
     
-    CHARACTER(360) :: string
+    CHARACTER(STRING_LEN) :: string
     INTEGER :: line_position,i
     LOGICAL :: space_start
 !********************************************************************************
@@ -244,7 +247,7 @@ END SUBROUTINE Read_String_Zeo
       IMPLICIT NONE
 
       INTEGER :: prefix_length
-      CHARACTER(120) :: prefix,new_name
+      CHARACTER(FILENAME_LEN) :: prefix, new_name
       CHARACTER(*) :: suffix
 
       prefix_length = LEN_TRIM(prefix)

--- a/Src/io_utilities.f90
+++ b/Src/io_utilities.f90
@@ -86,7 +86,7 @@ CONTAINS
 ! different by detecting a space between entries. It also tests to see if the 
 ! minimum number of entries specified was met or not. If not, and error is returned.
 !********************************************************************************
-    CHARACTER(120), INTENT(OUT) :: line_array(20)
+    CHARACTER(120), INTENT(OUT) :: line_array(60)
     INTEGER, INTENT(IN) :: file_number,min_entries,line_nbr
     INTEGER, INTENT(OUT) :: nbr_entries
     INTEGER, INTENT(INOUT) :: ierr
@@ -107,7 +107,10 @@ CONTAINS
       
 ! Read the string from the file
     CALL Read_String(file_number,string,ierr)
-    
+
+    WRITE(*,*) string
+    WRITE(*,*) LEN_TRIM(string)
+
     IF (string(1:1) .NE. '!') THEN
        IF (string(1:1) .NE. ' ') THEN
           ! first character is an entry, so advance counter

--- a/Src/io_utilities.f90
+++ b/Src/io_utilities.f90
@@ -63,15 +63,15 @@ CONTAINS
   SUBROUTINE Read_String(file_number,string,ierr)
 !********************************************************************************
 ! This routine just reads a single string from a file with unit number
-! equal to file_number and returns that 120 character string. It returns
+! equal to file_number and returns that 360 character string. It returns
 ! ierr .ne. 0 if it couldn't read the file.
 !********************************************************************************
     INTEGER, INTENT(IN) :: file_number
     INTEGER, INTENT(OUT) :: ierr
-    CHARACTER(120), INTENT(OUT) :: string
+    CHARACTER(360), INTENT(OUT) :: string
 !********************************************************************************
 
-    READ(file_number,'(A120)',IOSTAT=ierr) string
+    READ(file_number,'(A360)',IOSTAT=ierr) string
     IF (ierr .NE. 0) RETURN
 
   END SUBROUTINE Read_String
@@ -86,12 +86,12 @@ CONTAINS
 ! different by detecting a space between entries. It also tests to see if the 
 ! minimum number of entries specified was met or not. If not, and error is returned.
 !********************************************************************************
-    CHARACTER(120), INTENT(OUT) :: line_array(60)
+    CHARACTER(360), INTENT(OUT) :: line_array(60)
     INTEGER, INTENT(IN) :: file_number,min_entries,line_nbr
     INTEGER, INTENT(OUT) :: nbr_entries
     INTEGER, INTENT(INOUT) :: ierr
     
-    CHARACTER(120) :: string
+    CHARACTER(360) :: string
     INTEGER :: line_position,i
     LOGICAL :: space_start
 !********************************************************************************
@@ -107,9 +107,6 @@ CONTAINS
       
 ! Read the string from the file
     CALL Read_String(file_number,string,ierr)
-
-    WRITE(*,*) string
-    WRITE(*,*) LEN_TRIM(string)
 
     IF (string(1:1) .NE. '!') THEN
        IF (string(1:1) .NE. ' ') THEN

--- a/Src/make_config.f90
+++ b/Src/make_config.f90
@@ -70,7 +70,7 @@
 
     LOGICAL :: overlap, cbmc_overlap
 
-    CHARACTER*120 :: init_config_file, init_config_file1
+    CHARACTER(FILENAME_LEN) :: init_config_file, init_config_file1
 !*******************************************************************************
     ! Place molecules in the box using CB growth.
 

--- a/Src/mcf_control.f90
+++ b/Src/mcf_control.f90
@@ -48,7 +48,7 @@ SUBROUTINE MCF_Control
   IMPLICIT NONE
 
   INTEGER :: ierr,line_nbr,nbr_entries, i,j, ii,this_mol
-  CHARACTER(120) :: line_string, line_array(20)
+  CHARACTER(120) :: line_string, line_array(60)
   REAL(DP) :: e_total_bond, e_total_angle, e_total_intra_nb, e_total_inter_nb
   REAL(DP) ::  E_bond, E_angle, E_dihedral, E_improper
   REAL(DP) :: E_intra_vdw, E_intra_qq, E_inter_vdw, E_inter_qq, W_intra_vdw, W_intra_qq

--- a/Src/mcf_control.f90
+++ b/Src/mcf_control.f90
@@ -48,7 +48,7 @@ SUBROUTINE MCF_Control
   IMPLICIT NONE
 
   INTEGER :: ierr,line_nbr,nbr_entries, i,j, ii,this_mol
-  CHARACTER(360) :: line_string, line_array(60)
+  CHARACTER(STRING_LEN) :: line_string, line_array(60)
   REAL(DP) :: e_total_bond, e_total_angle, e_total_intra_nb, e_total_inter_nb
   REAL(DP) ::  E_bond, E_angle, E_dihedral, E_improper
   REAL(DP) :: E_intra_vdw, E_intra_qq, E_inter_vdw, E_inter_qq, W_intra_vdw, W_intra_qq

--- a/Src/mcf_control.f90
+++ b/Src/mcf_control.f90
@@ -48,7 +48,7 @@ SUBROUTINE MCF_Control
   IMPLICIT NONE
 
   INTEGER :: ierr,line_nbr,nbr_entries, i,j, ii,this_mol
-  CHARACTER(120) :: line_string, line_array(60)
+  CHARACTER(360) :: line_string, line_array(60)
   REAL(DP) :: e_total_bond, e_total_angle, e_total_intra_nb, e_total_inter_nb
   REAL(DP) ::  E_bond, E_angle, E_dihedral, E_improper
   REAL(DP) :: E_intra_vdw, E_intra_qq, E_inter_vdw, E_inter_qq, W_intra_vdw, W_intra_qq

--- a/Src/nptmc_control.f90
+++ b/Src/nptmc_control.f90
@@ -67,7 +67,7 @@ SUBROUTINE NPTMC_Control
   IMPLICIT NONE
 
   INTEGER :: ierr,line_nbr,nbr_entries, i,j, ii,this_mol
-  CHARACTER(120) :: line_string, line_array(60)
+  CHARACTER(360) :: line_string, line_array(60)
   REAL(DP) :: e_total_bond, e_total_angle, e_total_intra_nb, e_total_inter_nb
   REAL(DP) ::  E_bond, E_angle, E_dihedral, E_improper
   REAL(DP) :: E_intra_vdw, E_intra_qq, E_inter_vdw, E_inter_qq, W_intra_vdw, W_intra_qq

--- a/Src/nptmc_control.f90
+++ b/Src/nptmc_control.f90
@@ -67,7 +67,7 @@ SUBROUTINE NPTMC_Control
   IMPLICIT NONE
 
   INTEGER :: ierr,line_nbr,nbr_entries, i,j, ii,this_mol
-  CHARACTER(360) :: line_string, line_array(60)
+  CHARACTER(STRING_LEN) :: line_string, line_array(60)
   REAL(DP) :: e_total_bond, e_total_angle, e_total_intra_nb, e_total_inter_nb
   REAL(DP) ::  E_bond, E_angle, E_dihedral, E_improper
   REAL(DP) :: E_intra_vdw, E_intra_qq, E_inter_vdw, E_inter_qq, W_intra_vdw, W_intra_qq

--- a/Src/nptmc_control.f90
+++ b/Src/nptmc_control.f90
@@ -67,7 +67,7 @@ SUBROUTINE NPTMC_Control
   IMPLICIT NONE
 
   INTEGER :: ierr,line_nbr,nbr_entries, i,j, ii,this_mol
-  CHARACTER(120) :: line_string, line_array(20)
+  CHARACTER(120) :: line_string, line_array(60)
   REAL(DP) :: e_total_bond, e_total_angle, e_total_intra_nb, e_total_inter_nb
   REAL(DP) ::  E_bond, E_angle, E_dihedral, E_improper
   REAL(DP) :: E_intra_vdw, E_intra_qq, E_inter_vdw, E_inter_qq, W_intra_vdw, W_intra_qq

--- a/Src/nvtmc_control.f90
+++ b/Src/nvtmc_control.f90
@@ -67,7 +67,7 @@ SUBROUTINE NVTMC_Control
   IMPLICIT NONE
 
   INTEGER :: ierr,line_nbr,nbr_entries, i,j, ii,this_mol
-  CHARACTER(360) :: line_string, line_array(60)
+  CHARACTER(STRING_LEN) :: line_string, line_array(60)
   REAL(DP) :: e_total_bond, e_total_angle, e_total_intra_nb, e_total_inter_nb
   REAL(DP) ::  E_bond, E_angle, E_dihedral, E_improper
   REAL(DP) :: E_intra_vdw, E_intra_qq, E_inter_vdw, E_inter_qq, W_intra_vdw, W_intra_qq

--- a/Src/nvtmc_control.f90
+++ b/Src/nvtmc_control.f90
@@ -67,7 +67,7 @@ SUBROUTINE NVTMC_Control
   IMPLICIT NONE
 
   INTEGER :: ierr,line_nbr,nbr_entries, i,j, ii,this_mol
-  CHARACTER(120) :: line_string, line_array(60)
+  CHARACTER(360) :: line_string, line_array(60)
   REAL(DP) :: e_total_bond, e_total_angle, e_total_intra_nb, e_total_inter_nb
   REAL(DP) ::  E_bond, E_angle, E_dihedral, E_improper
   REAL(DP) :: E_intra_vdw, E_intra_qq, E_inter_vdw, E_inter_qq, W_intra_vdw, W_intra_qq

--- a/Src/nvtmc_control.f90
+++ b/Src/nvtmc_control.f90
@@ -67,7 +67,7 @@ SUBROUTINE NVTMC_Control
   IMPLICIT NONE
 
   INTEGER :: ierr,line_nbr,nbr_entries, i,j, ii,this_mol
-  CHARACTER(120) :: line_string, line_array(20)
+  CHARACTER(120) :: line_string, line_array(60)
   REAL(DP) :: e_total_bond, e_total_angle, e_total_intra_nb, e_total_inter_nb
   REAL(DP) ::  E_bond, E_angle, E_dihedral, E_improper
   REAL(DP) :: E_intra_vdw, E_intra_qq, E_inter_vdw, E_inter_qq, W_intra_vdw, W_intra_qq

--- a/Src/participation.f90
+++ b/Src/participation.f90
@@ -80,8 +80,8 @@ SUBROUTINE Participation
 
   REAL(DP) :: x_this, y_this, z_this, this_l
 
-  CHARACTER(120) :: file_name, car_file, xyz_file, frag_name
-  CHARACTER(360) :: line_string
+  CHARACTER(FILENAME_LEN) :: file_name, car_file, xyz_file, frag_name
+  CHARACTER(STRING_LEN) :: line_string
 
   
 

--- a/Src/participation.f90
+++ b/Src/participation.f90
@@ -81,7 +81,7 @@ SUBROUTINE Participation
   REAL(DP) :: x_this, y_this, z_this, this_l
 
   CHARACTER(120) :: file_name, car_file, xyz_file, frag_name
-  CHARACTER(120) :: line_string
+  CHARACTER(360) :: line_string
 
   
 


### PR DESCRIPTION
## Description
1. Expands the maximum line length from 120 to 360 characters. 
2. Expands the maximum number of items per line from 20 to 60 items.
3. Switches to using a variable, `STRING_LEN` for the `line_string` and `line_array` declarations.

## Related Issue
Partially addresses #59 

## How Has This Been Tested?
See test files [here](https://gist.github.com/rsdefever/f3d8b6796dcd4ac75cf8552239a0bc42). This is the propane example, but I have extended the fragment line of the MCF file to extend over 120 characters. This fails with the current version of Cassandra, but succeeds after applying my fix.

## Backward Compatibility
Fully backwards compatible.

## Further Information, Files, and Links
**Please** look over this carefully to make sure I didn't miss anything as these changes involved several files.
