### PR TITLE
Fix/ring fragments

### DIFF
--- a/Documentation/Tex/howto.tex
+++ b/Documentation/Tex/howto.tex
@@ -82,7 +82,13 @@ that the ring group contains all the ring atoms and those directly
 bonded to the ring atoms. For each fragment identified, Cassandra runs
 a pre\textendash simulation in the gas phase to sample the intramolecular degrees
 of freedom. A library of a large number of these conformations are
-stored for use in an actual simulation. \\ \\
+stored for use in an actual simulation. \emph{Note that intramolecular
+degrees of freedom may not be properly sampled in fused-ring systems. We
+highly encourage anyone simulating such systems to compare the internal
+angle and dihedral distributions in the fragment library with a 
+constrained bond length molecular dynamics simulation of the relevant fragment
+in vacuum.}\\ \\
+
 %
 %
 The gas phase library generation has been automated with the script \texttt{library\_setup.py} located in the \texttt{Scripts/Frag\_Library\_Setup}

--- a/Documentation/Tex/introduction.tex
+++ b/Documentation/Tex/introduction.tex
@@ -6,7 +6,8 @@ aqueous solutions and ionic liquids. It handles a standard ``Class
 I''-type force field having fixed bond lengths, harmonic bond angles
 and improper angles, a CHARMM or OPLS-style dihedral potential, a
 Lennard-Jones 12-6 potential and fixed partial charges. It does {\em
-  not} treat flexible bond lengths. Cassandra uses OpenMP parallelization and comes
+  not} treat flexible bond lengths. Fused ring systems should
+  be simulated with caution. Cassandra uses OpenMP parallelization and comes
 with a number of scripts, utilities and examples to help with
 simulation setup. \\ \\ 
 %

--- a/Src/move_ring_flip.f90
+++ b/Src/move_ring_flip.f90
@@ -85,12 +85,18 @@ SUBROUTINE Flip_Move
 
   ! save the orignal coordinates
   Call Save_Old_Cartesian_Coordinates(im,is)
-  
-  ! Choose a ring atom to flip
-  atom_num = INT ( rranf() * nring_atoms(is)) + 1
 
-  ! obtain id 
-  this_atom = ring_atom_ids(atom_num,is)
+  ! This do loop is safe b/c ring_fragment_driver
+  ! confirms that not all ring_atoms are multiring_atoms
+  DO WHILE (.TRUE.)
+    ! Choose a ring atom to flip
+    atom_num = INT ( rranf() * nring_atoms(is)) + 1
+    ! obtain id
+    this_atom = ring_atom_ids(atom_num,is)
+    IF (nonbond_list(this_atom, is)%multiring_atom .EQV. .FALSE.) THEN
+       EXIT
+    ENDIF
+  END DO
 
   ! Figure out the bond angle that contains this_atom at the apex
   DO i = 1, angle_part_list(this_atom,is)%nangles

--- a/Src/participation.f90
+++ b/Src/participation.f90
@@ -527,10 +527,8 @@ SUBROUTINE Participation
                    ! and all other do not need to be scaled by kboltz. Valid for LJ and Mie.
                    ! Other (and future) potentials perhaps not.
                    IF (j == 1) THEN
-                     !WRITE(201,'(F11.7,2X)',ADVANCE='NO') nonbond_list(ia,is)%vdw_param(j)/kboltz
                      WRITE(201,'(F11.7,2X)',ADVANCE='NO') nonbond_list(this_atom,is)%vdw_param(j)/kboltz
                    ELSE
-                     !WRITE(201,'(F11.7,2X)',ADVANCE='NO') nonbond_list(ia,is)%vdw_param(j)
                      WRITE(201,'(F11.7,2X)',ADVANCE='NO') nonbond_list(this_atom,is)%vdw_param(j)
                    END IF
                  END DO

--- a/Src/participation.f90
+++ b/Src/participation.f90
@@ -527,9 +527,11 @@ SUBROUTINE Participation
                    ! and all other do not need to be scaled by kboltz. Valid for LJ and Mie.
                    ! Other (and future) potentials perhaps not.
                    IF (j == 1) THEN
-                     WRITE(201,'(F11.7,2X)',ADVANCE='NO') nonbond_list(ia,is)%vdw_param(j)/kboltz
+                     !WRITE(201,'(F11.7,2X)',ADVANCE='NO') nonbond_list(ia,is)%vdw_param(j)/kboltz
+                     WRITE(201,'(F11.7,2X)',ADVANCE='NO') nonbond_list(this_atom,is)%vdw_param(j)/kboltz
                    ELSE
-                     WRITE(201,'(F11.7,2X)',ADVANCE='NO') nonbond_list(ia,is)%vdw_param(j)
+                     !WRITE(201,'(F11.7,2X)',ADVANCE='NO') nonbond_list(ia,is)%vdw_param(j)
+                     WRITE(201,'(F11.7,2X)',ADVANCE='NO') nonbond_list(this_atom,is)%vdw_param(j)
                    END IF
                  END DO
                  IF (nonbond_list(this_atom,is)%ring_atom) THEN

--- a/Src/type_definitions.f90
+++ b/Src/type_definitions.f90
@@ -228,7 +228,7 @@ MODULE Type_Definitions
      REAL(DP) :: mass, charge
      INTEGER :: atom_type_number
 
-     LOGICAL :: ring_atom
+     LOGICAL :: ring_atom, multiring_atom
 
   END TYPE Nonbond_Class
   !****************************************************************************


### PR DESCRIPTION
## Description
This PR has two major changes:
1. A bug fix for the MCF generation for fragment library generation. The MCFs previously used the LJ parameters from the first fragment atom for all the atoms in the fragment. Since branched fragments only contain 1-2 interactions, which are normally set to `0.0`, this fix has no material impact in those systems. However, ring fragments can contain 1-4, 1-5, etc. interactions which may be non-zero. In ring fragments with multiple atom types the interactions were therefore incorrect. This resulted in incorrect bond angle distributions in the fragment libraries for certain molecules, e.g., all atom benzene.
2. The ability to generate ring fragments for (simple) fused ring systems. The current code attempts ring flip moves on all ring atoms. In a fused-ring system (e.g., naphthalene), this results in the bond lengths being not preserved. The PR implements the identification of so-called "multiring" atoms, which participate in multiple rings. No ring flip moves are attempted on the multiring atoms. This at least preserves the bond lengths and generates the correct bond angle distribution for a simple test cases (naphthalene). I suspect this scheme will fail for more complex (i.e., larger) fused ring systems. However, in this case the fragments will be so large as to render the CBMC scheme nearly useless anyway. Warnings have been added to the user manual that care should be taken when simulating fused-ring systems.

## How Has This Been Tested?
The bugfix was tested by comparing the bond angle distributions for all atom benzene with constrained MD before and after the bugfix. Before the bugfix the bond angle distributions did not match. After the bugfix they agreed with constrained MD. The "multiring" atom scheme was tested via the same approach with all atom naphthalene. Once again, the distributions matched.

## Backward Compatibility
Input file backward compatibility is maintained.

## Post Submission Checklist
Please check the fields below as they are completed

- [x] Suitable new documentation files and/or updates to the existing docs are included.
