### PR TITLE
Add up to 23 character atom name support for custom mixing rules

### DIFF
--- a/Src/create_nonbond_table.f90
+++ b/Src/create_nonbond_table.f90
@@ -58,7 +58,7 @@
   IMPLICIT NONE
 
   LOGICAL :: repeat_type
-  CHARACTER(20), DIMENSION(:), ALLOCATABLE :: temp_atomtypes ! same dimension as atom_name
+  CHARACTER(23), DIMENSION(:), ALLOCATABLE :: temp_atomtypes ! same dimension as atom_name
   INTEGER :: ii, is, ia, itype, jtype, iset,jset,k,itype_1,itype_2
   REAL(DP) :: eps_i, eps_j, sig_i, sig_j
   INTEGER, DIMENSION(:,:), ALLOCATABLE :: vdw_param_set
@@ -150,7 +150,7 @@
      WRITE(logunit,'(A)') &
           ' There are '//TRIM(Int_To_String(nbr_atomtypes))//' different atom types in the system '
      DO ii = 1, nbr_atomtypes
-        WRITE(logunit,'(3x,I3,2x,A20)') ii, temp_atomtypes(ii)
+        WRITE(logunit,'(3x,I3,2x,A23)') ii, temp_atomtypes(ii)
      ENDDO
 
      WRITE(logunit,*)
@@ -163,7 +163,7 @@
 
         IF (natoms(is) < 100) THEN
           DO ia = 1, natoms(is)
-             WRITE(logunit,'(X,A20,T12,I4)') nonbond_list(ia,is)%atom_name, &
+             WRITE(logunit,'(X,A23,T12,I4)') nonbond_list(ia,is)%atom_name, &
                   nonbond_list(ia,is)%atom_type_number
           ENDDO
         ELSE
@@ -224,10 +224,10 @@
 
   ! Write header for logfile output. Specific for the vdw style
      IF (int_vdw_style(1) == vdw_lj) THEN
-        WRITE(logunit,'(X,A8,5X,A8,2X,A12,X,A12)') 'Atom 1','Atom 2', 'epsilon', 'sigma'
-        WRITE(logunit,'(X,8X,5X,8X,2X,A12,X,A12)') 'amu A^2/ps^2', 'Ang'
+        WRITE(logunit,'(X,A23,5X,A23,2X,A12,X,A12)') 'Atom 1','Atom 2', 'epsilon', 'sigma'
+        WRITE(logunit,'(X,23X,5X,23X,2X,A12,X,A12)') 'amu A^2/ps^2', 'Ang'
      ELSEIF (int_vdw_style(1) == vdw_mie) THEN
-        WRITE(logunit,'(X,A8,5X,A8,2X,A12,X,A12,X,A12,X,A12)') 'Atom 1','Atom 2', 'epsilon', 'sigma', &
+        WRITE(logunit,'(X,A23,5X,A23,2X,A12,X,A12,X,A12,X,A12)') 'Atom 1','Atom 2', 'epsilon', 'sigma', &
               'rep-expt', 'disp-expt'
         WRITE(logunit,'(X,8X,5X,8X,2X,A12,X,A12)') 'amu A^2/ps^2', 'Ang'
      ENDIF
@@ -259,7 +259,7 @@
 
                  ! Report parameters to logfile.
                  IF (verbose_log) THEN
-                   WRITE(logunit,'(X,A8,5X,A8,2X,F12.4,X,F12.4)') &
+                   WRITE(logunit,'(X,A23,5X,A23,2X,F12.4,X,F12.4)') &
                         atom_type_list(itype), atom_type_list(itype), &
                         vdw_param1_table(itype,itype), &
                         vdw_param2_table(itype,itype)
@@ -293,7 +293,7 @@
 
                  ! Report parameters to logfile.
                  IF (verbose_log) THEN
-                   WRITE(logunit,'(X,A8,5X,A8,2X,F12.4,X,F12.4,X,F12.4,X,F12.4)') &
+                   WRITE(logunit,'(X,A23,5X,A23,2X,F12.4,X,F12.4,X,F12.4,X,F12.4)') &
                         atom_type_list(itype), atom_type_list(itype), &
                         vdw_param1_table(itype,itype), vdw_param2_table(itype,itype), &
                         vdw_param3_table(itype,itype), vdw_param4_table(itype,itype)
@@ -351,7 +351,7 @@
 
                  ! Report parameters to logfile.
                  IF (verbose_log) THEN
-                   WRITE(logunit,'(X,A8,5X,A8,2X,F12.4,X,F12.4)') &
+                   WRITE(logunit,'(X,A23,5X,A23,2X,F12.4,X,F12.4)') &
                         atom_type_list(itype), atom_type_list(jtype), &
                         vdw_param1_table(itype,jtype), vdw_param2_table(itype,jtype)
                  ENDIF
@@ -401,7 +401,7 @@
 
                     ! Report parameters to logfile.
                     IF (verbose_log) THEN
-                      WRITE(logunit,'(X,A8,5X,A8,2X,F12.4,X,F12.4,X,F12.4,X,F12.4)') &
+                      WRITE(logunit,'(X,A23,5X,A23,2X,F12.4,X,F12.4,X,F12.4,X,F12.4)') &
                            atom_type_list(itype), atom_type_list(jtype), &
                            vdw_param1_table(itype,jtype), vdw_param2_table(itype,jtype), &
                            vdw_param3_table(itype,jtype), vdw_param4_table(itype,jtype)
@@ -493,7 +493,7 @@
                   !Sigma
                   vdw_param2_table(itype,jtype) = String_To_Double(line_array(4))
                   IF (verbose_log) THEN
-                    WRITE(logunit,'(X,A8,5X,A8,2(X,F12.4))') &
+                    WRITE(logunit,'(X,A23,5X,A23,2(X,F12.4))') &
                          atom_type_list(itype), atom_type_list(jtype), &
                          vdw_param1_table(itype,jtype), &
                          vdw_param2_table(itype,jtype)
@@ -516,7 +516,7 @@
                   !Dispersive exponent
                   vdw_param4_table(itype,jtype) = String_To_Double(line_array(6))
                   IF (verbose_log) THEN
-                    WRITE(logunit,'(X,A8,5X,A8,4(X,F12.4))') &
+                    WRITE(logunit,'(X,A23,5X,A23,4(X,F12.4))') &
                          atom_type_list(itype), atom_type_list(jtype), &
                          vdw_param1_table(itype,jtype), &
                          vdw_param2_table(itype,jtype), &

--- a/Src/global_variables.f90
+++ b/Src/global_variables.f90
@@ -87,7 +87,7 @@ USE Type_Definitions
 
   ! The starting seed for the random generator
   ! Note iseed is used for generating points on random sphere for MCF_Gen sim type.
- INTEGER (KIND=8) :: iseed, iseed1, iseed3
+  INTEGER (KIND=8) :: iseed, iseed1, iseed3
 
   ! Variables associated with the nonbond potential
   CHARACTER(15) :: mix_rule, run_type
@@ -307,7 +307,7 @@ USE Type_Definitions
 
   ! array containing name of each atom type with idex = atomtype number.
   ! It is set and allocated to size nbr_atomtypes in Create_Nonbond_Table
-  CHARACTER(8), DIMENSION(:), ALLOCATABLE :: atom_type_list
+  CHARACTER(23), DIMENSION(:), ALLOCATABLE :: atom_type_list
 
   INTEGER, DIMENSION(:), ALLOCATABLE :: nbr_vdw_params
 

--- a/Src/participation.f90
+++ b/Src/participation.f90
@@ -233,7 +233,7 @@ SUBROUTINE Participation
           WRITE(logunit,*)
           WRITE(logunit,*) 'For species', is
           WRITE(logunit,*) ' Number of atoms that can be displaced', species_list(is)%ndisp_atoms
-          WRITE(logunit,'(2(A20,2x))') 'Atom ID', 'Reference Atom ID'
+          WRITE(logunit,'(2(A23,2x))') 'Atom ID', 'Reference Atom ID'
           DO iatom = 1, species_list(is)%ndisp_atoms
              WRITE(logunit,'(2(I20,2x))') species_list(is)%disp_atom_id(iatom), &
                   species_list(is)%disp_atom_ref(iatom)
@@ -518,7 +518,7 @@ SUBROUTINE Participation
 
                  ! Check to see if this atom is a ring fragment, if so append, 'ring' at the end
 
-                 WRITE(201,'(I5,2X,A20,2X,A6,2X,2(F11.7,2X),A6,2X)',ADVANCE='NO') i, &
+                 WRITE(201,'(I5,2X,A23,2X,A6,2X,2(F11.7,2X),A6,2X)',ADVANCE='NO') i, &
                       nonbond_list(this_atom,is)%atom_name, nonbond_list(this_atom,is)%element, &
                       nonbond_list(this_atom,is)%mass, nonbond_list(this_atom,is)%charge, &
                       nonbond_list(this_atom,is)%vdw_type
@@ -543,7 +543,7 @@ SUBROUTINE Participation
            ELSE
               
               WRITE(201,*) bondpart_list(ia,is)%nbonds + 1
-              WRITE(201,'(I5,2X,A20,2X,A6,2X,2(F11.7,2X),A6,2X)',ADVANCE='NO') anchor_atom, &
+              WRITE(201,'(I5,2X,A23,2X,A6,2X,2(F11.7,2X),A6,2X)',ADVANCE='NO') anchor_atom, &
                         nonbond_list(ia,is)%atom_name, &
                         nonbond_list(ia,is)%element, &
                         nonbond_list(ia,is)%mass, &
@@ -576,7 +576,7 @@ SUBROUTINE Participation
                  
                  this_atom = frag_list(ifrag,is)%atoms(i)
                  
-                 WRITE(201,'(I5,2X,A20,2X,A6,2X,2(F11.7,2X),A6,2X)',ADVANCE='NO') i, &
+                 WRITE(201,'(I5,2X,A23,2X,A6,2X,2(F11.7,2X),A6,2X)',ADVANCE='NO') i, &
                                 nonbond_list(this_atom,is)%atom_name, &
                                 nonbond_list(this_atom,is)%element, &
                                 nonbond_list(this_atom,is)%mass, &

--- a/Src/type_definitions.f90
+++ b/Src/type_definitions.f90
@@ -223,7 +223,7 @@ MODULE Type_Definitions
      REAL(DP), DIMENSION(max_nonbond_params) :: vdw_param
 
      CHARACTER(6) :: element
-     CHARACTER(20) :: atom_name
+     CHARACTER(23) :: atom_name
 
      REAL(DP) :: mass, charge
      INTEGER :: atom_type_number


### PR DESCRIPTION
## Description
Atom names were recently extended up to twenty characters (#19). However, the maximum length of the custom mixing rules remained at 6 characters. This PR fixes that error. This PR also extends the supported character length to 23, with the 3 extra characters to support the `_s1` or `_s2` ..., often appended by `library_setup.py`. Our reported limit for atom names remains 20 characters.

## How Has This Been Tested?
User who reported the bug has confirmed that it now works for their system.

## Backward Compatibility
Fully backwards compatible.