### PR TITLE
Add bump2version configuration file

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,8 @@
+[bumpversion]
+current_version = 1.2.2
+commit = True
+tag = True
+
+[bumpversion:file:Src/main.f90]
+
+[bumpversion:file:Documentation/Tex/title.tex]

--- a/Src/main.f90
+++ b/Src/main.f90
@@ -106,7 +106,7 @@ PROGRAM Main
 
 !********************************************************************************
 ! Code name and version. Change as updates are made.
-  version = 'Cassandra Version 1.2.2 20200326'
+  version = 'Cassandra Version 1.2.2'
 ! Get starting time information (intrinsic function)
   CALL DATE_AND_TIME(date,time,zone,begin_values)
   CALL cpu_time(start_time)


### PR DESCRIPTION
## Description
Adds a configuration file for `bump2version`. 

`bump2version` (https://github.com/c4urself/bump2version) is a super lightweight version management package. Issuing a new release is now as easy as `bump2version patch`, `bump2version minor` or `bump2version major`.

## How Has This Been Tested?
Locally tested.
