### PR TITLE
Bugfix for gfortran multiring atoms

### DIFF
--- a/Src/input_routines.f90
+++ b/Src/input_routines.f90
@@ -1557,7 +1557,9 @@ SUBROUTINE Get_Atom_Info(is)
            END SELECT
 
            ! the last entry is 'ring' for ring atoms
+           ! multiring atoms are ID'd in ring_fragment_driver.f90
            nonbond_list(ia,is)%ring_atom = .FALSE.
+           nonbond_list(ia,is)%multiring_atom = .FALSE.
            IF (line_array(nbr_entries) == 'ring') THEN
               nring_atoms(is) = nring_atoms(is) + 1
               ring_atom_ids(nring_atoms(is),is) = ia


### PR DESCRIPTION
## Description
Bugfix for `multiring_atom` identification. Affected `gfortran` compiled versions but not `ifort` versions. Bug introduced in #67. The previous PR was inadvertently tested with `ifort` only. 
