### PR TITLE
Allow dashes in file names

### DIFF
--- a/Src/io_utilities.f90
+++ b/Src/io_utilities.f90
@@ -486,7 +486,8 @@ SUBROUTINE Check_String(string_in,ierr)
      IF ( .NOT. ((string_in(i:i) >=  'A' .AND. (string_in(i:i) <= 'Z')) .OR. &
           (string_in(i:i) >= 'a' .AND. (string_in(i:i) <= 'z')) .OR. &
           (string_in(i:i) >= '0' .AND. (string_in(i:i) <= '9')) .OR. &
-          (string_in(i:i) == '.' .OR. string_in(i:i) == '_' .OR. string_in(i:i) == '/'))) THEN
+          (string_in(i:i) == '.' .OR. string_in(i:i) == '_' .OR. &
+         string_in(i:i) == '-' .OR. string_in(i:i) == '/'))) THEN
         ! character other than letters and digits found
         ierr = 1
         RETURN


### PR DESCRIPTION

## Description
I modified subroutine Check_String in io_utilities.f90 to allow "-" dashes in file names.

## Related Issue
Closes #88 

## How Has This Been Tested?
I've allowed dashes in Check_String, then compiled and tested it by starting from a checkpoint file with a dash in the file name.  The simulation ran normally with no errors.

## Backward Compatibility
Nothing breaks backward compatibility for inputs.

## Post Submission Checklist
Not applicable because this removes an undesired obstacle not mentioned in the documentation.

