### PR TITLE
Correct dimension labels in Apply_PBC_Anint.

### DIFF
--- a/Src/minimum_image_separation.f90
+++ b/Src/minimum_image_separation.f90
@@ -145,10 +145,10 @@ SUBROUTINE Apply_PBC_Anint(ibox,rxijp,ryijp,rzijp,rxij,ryij,rzij)
           REAL(ANINT( rxijp / box_list(ibox)%length(1,1)), DP)
 
      ryij = ryijp - box_list(ibox)%length(2,2)* &
-          REAL(ANINT( rxijp / box_list(ibox)%length(2,2)), DP)
+          REAL(ANINT( ryijp / box_list(ibox)%length(2,2)), DP)
 
      rzij = rzijp - box_list(ibox)%length(3,3)* &
-          REAL(ANINT( rxijp / box_list(ibox)%length(3,3)), DP)
+          REAL(ANINT( rzijp / box_list(ibox)%length(3,3)), DP)
 
   ELSE
      


### PR DESCRIPTION
## Description
I corrected the dimension labels in the determination of the y and z box images to the corresponding dimension.

## Related Issue
Closes #95 
