### PR TITLE
Extend maximum number of MC steps by using INT64 for counters

### DIFF
--- a/Src/global_variables.f90
+++ b/Src/global_variables.f90
@@ -49,6 +49,7 @@ MODULE Global_Variables
   ! 03/17/15 (JS) : lactivity defined for GCMC simulations
 !*********************************************************************************
 
+USE ISO_FORTRAN_ENV
 USE Type_Definitions
 
   SAVE
@@ -83,7 +84,7 @@ USE Type_Definitions
   INTEGER, PARAMETER :: sim_mcf = 9
   LOGICAL :: timed_run, openmp_flag, en_flag, verbose_log, input_is_logfile
   CHARACTER(10) :: sim_length_units
-  INTEGER :: steps_per_sweep
+  INTEGER (KIND=INT64):: steps_per_sweep
 
   ! The starting seed for the random generator
   ! Note iseed is used for generating points on random sphere for MCF_Gen sim type.
@@ -99,7 +100,7 @@ USE Type_Definitions
   INTEGER, PARAMETER :: run_prod = 1
   INTEGER, PARAMETER :: run_test = 2
   LOGICAL :: change_to_production = .false.
-  INTEGER :: nsteps_until_prod
+  INTEGER (KIND=INT64):: nsteps_until_prod
   INTEGER, PARAMETER :: vdw_none = 0
   INTEGER, PARAMETER :: vdw_lj = 1
   INTEGER, PARAMETER :: vdw_cut = 2
@@ -487,7 +488,7 @@ USE Type_Definitions
 
   ! Timing information
   ! Initial, current and final number of steps
-  INTEGER :: i_mcstep, initial_mcstep, n_mcsteps, n_equilsteps, iblock
+  INTEGER (KIND=INT64) :: i_mcstep, initial_mcstep, n_mcsteps, n_equilsteps, iblock
   ! Information on the output of data
   INTEGER :: nthermo_freq, ncoord_freq, block_avg_freq, nbr_blocks
   REAL(DP) :: data_points_per_block

--- a/Src/io_utilities.f90
+++ b/Src/io_utilities.f90
@@ -60,6 +60,11 @@ MODULE IO_Utilities
 
   INTEGER, PARAMETER :: STRING_LEN = 360
 
+  INTERFACE Int_To_String
+    MODULE PROCEDURE Int64_To_String
+    MODULE PROCEDURE Int32_To_String
+  END INTERFACE
+
 CONTAINS
 
 !********************************************************************************
@@ -258,7 +263,21 @@ END SUBROUTINE Read_String_Zeo
 
 
 !****************************************************************************
-    FUNCTION Int_To_String(int_in)
+    FUNCTION Int32_To_String(int_in)
+!****************************************************************************
+      IMPLICIT NONE
+
+      INTEGER(KIND=INT32), INTENT(IN) :: int_in
+      CHARACTER(40) :: int32_to_string
+      INTEGER(KIND=INT64) :: int_64_in
+
+      int_64_in = INT(int_in, INT64)
+      int32_to_string = Int64_To_String(int_64_in)
+
+    END FUNCTION Int32_To_String
+
+!****************************************************************************
+    FUNCTION Int64_To_String(int_in)
 !****************************************************************************
       IMPLICIT NONE
   !**************************************************************************
@@ -267,16 +286,17 @@ END SUBROUTINE Read_String_Zeo
   ! and returns the character equivalent
   !                                                                         *
   !**************************************************************************
-  CHARACTER(40) :: int_to_string
+  INTEGER(KIND=INT64), INTENT(IN) :: int_in
+  CHARACTER(40) :: int64_to_string
   LOGICAL :: is_negative
-  INTEGER :: int_in, chop_int, ndigits, curr_digit
-  
-  int_to_string = ""
+  INTEGER(KIND=INT64) :: chop_int, ndigits, curr_digit
+
+  int64_to_string = ""
   ndigits = 0
   
   !Check to see if integer is zero
   IF (int_in == 0) THEN
-     int_to_string(1:1) = "0"
+     int64_to_string(1:1) = "0"
      RETURN
   END IF
   
@@ -294,17 +314,17 @@ END SUBROUTINE Read_String_Zeo
   DO
      ndigits = ndigits + 1
      curr_digit = MOD(chop_int,10)
-     int_to_string(41-ndigits:41-ndigits) = ACHAR(curr_digit+48)
+     int64_to_string(41-ndigits:41-ndigits) = ACHAR(curr_digit+48)
      chop_int = INT(chop_int / 10.0d0)
      IF (chop_int == 0) EXIT
   END DO
   
-  IF (is_negative) int_to_string(40-ndigits:40-ndigits) = "-"
+  IF (is_negative) int64_to_string(40-ndigits:40-ndigits) = "-"
   
   !Left justify string
-  int_to_string = ADJUSTL(int_to_string)
+  int64_to_string = ADJUSTL(int64_to_string)
   
-END FUNCTION Int_To_String
+END FUNCTION Int64_To_String
 
 
 !****************************************************************************

--- a/Src/io_utilities.f90
+++ b/Src/io_utilities.f90
@@ -313,9 +313,9 @@ END SUBROUTINE Read_String_Zeo
   !left
   DO
      ndigits = ndigits + 1
-     curr_digit = MOD(chop_int,10)
+     curr_digit = MOD(chop_int, 10)
      int64_to_string(41-ndigits:41-ndigits) = ACHAR(curr_digit+48)
-     chop_int = INT(chop_int / 10.0d0)
+     chop_int = INT(chop_int / 10.0_REAL128, KIND=INT64)
      IF (chop_int == 0) EXIT
   END DO
   


### PR DESCRIPTION
## Description
Closes #97. Changes all step-related variables to `KIND=INT64`. I searched through the code base and I believe I found all the counters related to the number of steps in a simulation. 

I tested this code _with the intel compiler_ on the examples in #97, and after the fix the previously failed simulation runs fine.

**Edit:** I added some simple tests of the functions in a gist [here](https://gist.github.com/rsdefever/1bbb58e9407cae6826dd07cb270173f6). I also tested the example in #97 with `gfortran`.

## Backward Compatibility
No backward compatibility issues.
