### PR TITLE
Improve miscellaneous things regarding solid simulations

### DIFF
--- a/Src/input_routines.f90
+++ b/Src/input_routines.f90
@@ -1604,7 +1604,7 @@ SUBROUTINE Get_Atom_Info(is)
 
         EXIT
 
-     ELSEIF (line_string(1:3) == 'END' .or. line_nbr > 10000) THEN
+     ELSEIF (line_string(1:3) == 'END' .or. line_nbr > 50000) THEN
 
         ! Problem reading Atom_Info
         err_msg = ''
@@ -1758,7 +1758,7 @@ SUBROUTINE Get_Bond_Info(is)
 
         EXIT
 
-     ELSEIF (line_string(1:3) == 'END' .or. line_nbr > 10000) THEN
+     ELSEIF (line_string(1:3) == 'END' .or. line_nbr > 50000) THEN
 
         err_msg = ''
         err_msg(1) = 'Section "# Bond_Info" is missing from the mcf file and is required'
@@ -1916,7 +1916,7 @@ SUBROUTINE Get_Angle_Info(is)
 
         EXIT
 
-     ELSEIF (line_string(1:3) == 'END' .or. line_nbr > 10000) THEN
+     ELSEIF (line_string(1:3) == 'END' .or. line_nbr > 50000) THEN
 
         err_msg = ''
         err_msg(1) = 'Section "# Angle_Info" is missing from the mcf file and is required'
@@ -2172,7 +2172,7 @@ SUBROUTINE Get_Dihedral_Info(is)
 
         EXIT
 
-     ELSEIF (line_string(1:3) == 'END' .or. line_nbr > 10000) THEN
+     ELSEIF (line_string(1:3) == 'END' .or. line_nbr > 50000) THEN
 
         err_msg = ''
         err_msg(1) = 'Section "# Dihedral_Info" is missing from the mcf file and is required'
@@ -2328,7 +2328,7 @@ INTEGER, INTENT(IN) :: is
 
         EXIT
 
-     ELSEIF (line_string(1:3) == 'END' .or. line_nbr > 10000) THEN
+     ELSEIF (line_string(1:3) == 'END' .or. line_nbr > 50000) THEN
 
         err_msg = ''
         err_msg(1) = 'Section "# Improper_Info" is missing from the mcf file and is required'
@@ -2552,7 +2552,7 @@ SUBROUTINE Get_Fragment_Info(is)
 
         EXIT
 
-     ELSE IF (line_string(1:3) == 'END' .or. line_nbr > 10000) THEN
+     ELSE IF (line_string(1:3) == 'END' .or. line_nbr > 50000) THEN
 
         err_msg = ''
         err_msg(1) = 'Section "# Fragment_Info" is missing from the mcf file and is required'
@@ -2782,7 +2782,7 @@ SUBROUTINE Get_Fragment_Connectivity_Info(is)
 
         EXIT
 
-     ELSE IF (line_string(1:3) == 'END' .OR. line_nbr > 10000 ) THEN
+     ELSE IF (line_string(1:3) == 'END' .OR. line_nbr > 50000 ) THEN
 
         err_msg = ''
         err_msg(1) = 'Section "# Fragment_Connectivity" is missing from the mcf file and is required'
@@ -3393,7 +3393,7 @@ SUBROUTINE Get_Intra_Scaling(is)
 
         EXIT
 
-     ELSE IF (line_string(1:3) == 'END' .or. line_nbr > 10000) THEN
+     ELSE IF (line_string(1:3) == 'END' .or. line_nbr > 50000) THEN
 
         l_intra_scaling_mcf = .FALSE.
         WRITE(logunit,'(X,A)') 'Section "# Intra_Scaling" missing from mcf, will look in input file'
@@ -3468,7 +3468,7 @@ SUBROUTINE Get_Intra_Scaling(is)
 
            EXIT
 
-        ELSEIF (line_string(1:3) == 'END' .or. line_nbr > 10000) THEN
+        ELSEIF (line_string(1:3) == 'END' .or. line_nbr > 50000) THEN
 
            ! No intrascaling set explicitly - use default.
            WRITE(logunit,'(X,A)') 'Section "# Intra_Scaling" is missing from the input file'

--- a/Src/minimum_image_separation.f90
+++ b/Src/minimum_image_separation.f90
@@ -51,6 +51,7 @@ SUBROUTINE Minimum_Image_Separation(ibox,rxijp,ryijp,rzijp,rxij,ryij,rzij)
   REAL(DP), INTENT(IN) :: rxijp,ryijp,rzijp
   REAL(DP), INTENT(OUT) :: rxij,ryij,rzij
 
+  REAL(DP) :: sx, sy, sz
   REAL(DP), DIMENSION(3) :: temp_vec
   REAL(DP), DIMENSION(3) :: hbox   
  
@@ -86,41 +87,25 @@ SUBROUTINE Minimum_Image_Separation(ibox,rxijp,ryijp,rzijp,rxij,ryij,rzij)
 
   ELSE
 
-     ! Always use cell_matrix convention so this routine works for anything
+    !Always use cell_matrix convention so this routine works for anything
 
-     !First convert the parent coordinates from the Cartesian to fractional
-     !coordinate system
-     temp_vec(1) = box_list(ibox)%length_inv(1,1)*rxijp + &
-       box_list(ibox)%length_inv(1,2)*ryijp +          &
-       box_list(ibox)%length_inv(1,3)*rzijp
+    !First convert the parent coordinates from the Cartesian to fractional
+    !coordinate system
 
-     temp_vec(2) = box_list(ibox)%length_inv(2,1)*rxijp + &
-       box_list(ibox)%length_inv(2,2)*ryijp +          &
-       box_list(ibox)%length_inv(2,3)*rzijp
+    CALL Cartesian_To_Fractional(rxijp, ryijp, rzijp, sx, sy, sz, ibox)
 
-     temp_vec(3) = box_list(ibox)%length_inv(3,1)*rxijp + &
-       box_list(ibox)%length_inv(3,2)*ryijp +          &
-       box_list(ibox)%length_inv(3,3)*rzijp
+    !Apply periodic boundary conditions to the fractional distances.
+    ! Recall NINT rounds and does not truncate.
 
-     !Apply periodic boundary conditions to the fractional distances.
-     ! Recall NINT rounds and does not truncate.
-     temp_vec(1) = temp_vec(1) - REAL(NINT(temp_vec(1)),DP)
-     temp_vec(2) = temp_vec(2) - REAL(NINT(temp_vec(2)),DP)
-     temp_vec(3) = temp_vec(3) - REAL(NINT(temp_vec(3)),DP)
+    sx = sx - REAL(NINT(sx, DP))
+    sy = sy - REAL(NINT(sy, DP))
+    sz = sz - REAL(NINT(sz, DP))
   
-     !Convert back to Cartesian coordinates and return the results as
-     !the child coordinate separations
-     rxij = box_list(ibox)%length(1,1)*temp_vec(1) + &
-       box_list(ibox)%length(1,2)*temp_vec(2) +   &
-       box_list(ibox)%length(1,3)*temp_vec(3)
+    !Convert back to Cartesian coordinates and return the results as
+    !the child coordinate separations
 
-     ryij = box_list(ibox)%length(2,1)*temp_vec(1) + &
-       box_list(ibox)%length(2,2)*temp_vec(2) +   &
-       box_list(ibox)%length(2,3)*temp_vec(3)
+    CALL Fractional_To_Cartesian(sx, sy, sz, rxij, ryij, rzij, ibox)
 
-     rzij = box_list(ibox)%length(3,1)*temp_vec(1) + &
-       box_list(ibox)%length(3,2)*temp_vec(2) +   &
-       box_list(ibox)%length(3,3)*temp_vec(3)
 
   END IF
 


### PR DESCRIPTION
## Description
There are two changes included in this PR related to solid materials:

1) Some solids such as zeolites might have very long MCF, as each atom non bonded parameters must be specified. This might be problematic since the code looks for the keyword `END` within the first 10k lines. If it doesn't find it, an error is raised. The limit of 10k was simply raised to 50k.

2) The file `minimum_image_separation.f90` includes a functions to transform cartesian to fractional coordinates and viceversa. There was some legacy code that executed such calculations without using the included functions. The legacy code was removed and the functions are now used instead. 

## Related Issue
None

## How Has This Been Tested?
1) The test suite was executed. 
2) Long adsorption calculations of HFC in zeolites.

## Backward Compatibility
None