### PR TITLE
No broken bonds in input XYZ

### DIFF
--- a/Documentation/source/guides/input_files.rst
+++ b/Documentation/source/guides/input_files.rst
@@ -1102,6 +1102,18 @@ rejected and re-attempted.
         <element> <x> <y> <z>
         ...
 
+.. note::
+    The input ``.xyz`` file must not contain molecules with broken bonds.
+    For instance, a valid ``.xyz`` file for a long linear hydrocarbon can contain
+    some of its atoms outside the box boundaries.
+
+    An invalid ``.xyz`` file would contain coordinates "wrapped" across box boundaries,
+    causing unphysically long bonds.
+
+    Cassandra checks that the bonds computed in the initial configuration match those
+    provided in the MCF. If an invalid ``.xyz`` is provided, long bonds would be measured
+    and Cassandra would throw an error at the beginning of the simulation.
+
 -  | ``add_to_config`` will read the coordinates from an .xyz file,
      but then insert additional molecules. After ``add_to_config`` specify
      the number of molecules of each species to be read, followed by the


### PR DESCRIPTION
## Description
Clarify in the read_config subsection of the Start_Type section of the documentation
that the XYZ input file cannot contain coordinates of molecules
that are wrapped across box boundaries.

## Related Issue
#118 

## Post Submission Checklist
Please check the fields below as they are completed

- [x] Suitable new documentation files and/or updates to the existing docs are included.
- [x] My name is in the contributor list at `/Documentation/source/reference/acknowledgements.rst`
