### PR TITLE
lammpstrj converter script argument type fix

### DIFF
--- a/Scripts/Trajectory_Conversion/lammpstrjconvert.py
+++ b/Scripts/Trajectory_Conversion/lammpstrjconvert.py
@@ -237,6 +237,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "nmols",
+        type=int,
         nargs="+",
         help="List of integers containing"
         " the number of molecules of each species in the order in which the "

--- a/Src/input_routines.f90
+++ b/Src/input_routines.f90
@@ -340,7 +340,7 @@ SUBROUTINE Get_Sim_Type
            err_msg = ''
            err_msg(1) = 'Keyword ' // TRIM(line_array(1)) // ' on line number ' // &
                         TRIM(Int_To_String(line_nbr)) // ' of the input file is not supported'
-           err_msg(2) = 'Supported keywords are: nvt_mc, npt_mc, gemc, gemc_npt, gcmc,'
+           err_msg(2) = 'Supported keywords are: nvt_mc, npt_mc, gemc, gemc_npt, gcmc, pregen,'
            err_msg(3) = '                        nvt_mc_fragment, nvt_mc_ring_fragment, mcf_gen'
            CALL Clean_Abort(err_msg,'Get_Sim_Type')
         END IF


### PR DESCRIPTION
## Description
Previously, the `lammpstrjconvert.py` script would throw an error due to the argument `nmols` being taken as a list of strings by default.  I fixed it by specifying `type=int`.

I also added `pregen` to the listed allowable sim types in the error message displayed when an invalid sim type keyword is read from the input file.

## Related Issue
Closes #120 

## How Has This Been Tested?
The lammpstrjconvert.py script ran successfully after the implementation of the argument type fix.

## Backward Compatibility
No change.

## Post Submission Checklist
Please check the fields below as they are completed

- [ ] My name is in the contributor list at `/Documentation/source/reference/acknowledgements.rst`

## Further Information, Files, and Links
Any additional information here, attach relevant text or image files and URLs to external sites, publications , etc.
