### PR TITLE
Chargeless Widom insertion species with ewald fix

### DIFF
--- a/Src/widom_insert.f90
+++ b/Src/widom_insert.f90
@@ -139,7 +139,7 @@ SUBROUTINE Widom_Insert(is,ibox,widom_sum)
 
   END IF
   
-  IF (int_charge_style(ibox) == charge_coul) THEN
+  IF (int_charge_style(ibox) == charge_coul .AND. has_charge(is)) THEN
           CALL Compute_Molecule_Self_Energy(widom_locate,is,ibox,E_self)
           E_recip_in = energy(ibox)%reciprocal
   END IF


### PR DESCRIPTION


## Description
This PR makes the Widom_Insert subroutine not get the initial reciprocal energy or self energy when inserting test particles without charged atoms.

## Related Issue
Closes #122 

## How Has This Been Tested?
Cassandra was run for Widom insertions of neutral argon in molten NaCl with charge type ewald and yielded the same result as with charge type none.

## Backward Compatibility
No breakage.

## Post Submission Checklist
Please check the fields below as they are completed
- [x] My name is in the contributor list at `/Documentation/source/reference/acknowledgements.rst`
