### PR TITLE
Address various floating-point exceptions

### DIFF
--- a/Src/fragment_growth.f90
+++ b/Src/fragment_growth.f90
@@ -195,6 +195,7 @@ SUBROUTINE Build_Molecule(this_im,is,this_box,frag_order,this_lambda, &
   overlap_trial(:) = .FALSE.
   need_max_dcom = .FALSE.
 
+  weight(:) = 0.0_DP
 
   !*****************************************************************************
   ! Step 1) Select which fragment will be inserted first
@@ -1530,6 +1531,7 @@ SUBROUTINE Fragment_Placement(this_box, this_im, is, frag_start, frag_total, &
   config_list(:)%rzp = 0.0_DP
   dumcount = 0
   e_prev = e_total
+  weight(:) = 0.0_DP
 
   DO i = frag_start, frag_total
 
@@ -2012,7 +2014,6 @@ SUBROUTINE Fragment_Placement(this_box, this_im, is, frag_start, frag_total, &
            END IF
            
            nrg_kBT = beta(this_box) * nrg(ii)
-           weight(ii) = DEXP(-nrg_kBT)
            
            IF ( nrg_kBT >= max_kBT) THEN
               ! the energy is too high, set the weight to zero

--- a/Src/input_routines.f90
+++ b/Src/input_routines.f90
@@ -1406,6 +1406,8 @@ SUBROUTINE Get_Atom_Info(is)
   ring_atom_ids(:,is) = 0
   exo_atom_ids(:,is) = 0
 
+  species_list(is)%total_charge = 0.0_DP
+
   IF (.NOT. ALLOCATED (has_charge)) THEN
      ALLOCATE(has_charge(nspecies))
      has_charge(:) = .FALSE.
@@ -4182,12 +4184,16 @@ SUBROUTINE Get_Move_Probabilities
   prob_ring = 0.0_DP  ! sampling of ring atoms using flip move
   prob_atom_displacement = 0.0_DP ! sampling of atoms using atom displacement routine
   prob_identity_switch = 0.0_DP
+  species_list(:)%max_torsion = 0.0_DP
 
   ALLOCATE(sorbate_file(nspecies))
   ALLOCATE(init_list(MAXVAL(natoms),1,nspecies))
   ALLOCATE(max_disp(nspecies,nbr_boxes))
   ALLOCATE(max_rot(nspecies,nbr_boxes))
   ALLOCATE(prob_rot_species(nspecies))
+
+  max_disp(:,:) = 0.0_DP
+  max_rot(:,:) = 0.0_DP
 
   IF (int_sim_type == sim_pregen) RETURN
 
@@ -5633,6 +5639,7 @@ SUBROUTINE Get_CBMC_Info
   kappa_dih = 0
   need_kappa_ins = .FALSE.
   need_kappa_dih = .FALSE.
+  rcut_CBMC(:) = 0.0_DP
 
   DO is = 1, nspecies
      species_list(is)%l_coul_cbmc = .TRUE.


### PR DESCRIPTION
## Description
This fixes floating-point exceptions that were raised when running a Cassandra simulation. In particular, this commit fixed the IEEE_DENORMAL exceptions. The gfortran compiler options -ffpe-trap=denormal and -ffpe-summary=all were used to catch and show these exceptions in order to facilitate debugging.

Some options occurred when optimization flags were used, while others were happened when using the debug flag.

The fixes mostly involved initialization of variables, and a calculation of a Boltzmann weight of a very large energy. 

## Related Issue
#126 

## How Has This Been Tested?
Tests and and a longer NPT liquid pentane simulation

## Backward Compatibility
Yes

## Post Submission Checklist
Please check the fields below as they are completed

- [x] My name is in the contributor list at `/Documentation/source/reference/acknowledgements.rst`

## Further Information, Files, and Links
Description of the flags used by the gfortran compiler found [here](https://gcc.gnu.org/onlinedocs/gfortran/Debugging-Options.html#Debugging-Options)
