### PR TITLE
Fix GEMC examples and prevent log volume moves

### DIFF
--- a/Examples/GEMC/Diethylether/gemc_diethylether.inp
+++ b/Examples/GEMC/Diethylether/gemc_diethylether.inp
@@ -68,7 +68,6 @@ cubic
 # Prob_Volume
 0.005
 100.0
-100.0
 
 # Prob_Swap
 0.095

--- a/Examples/GEMC/Isobutane/gemc_isobutane.inp
+++ b/Examples/GEMC/Isobutane/gemc_isobutane.inp
@@ -70,7 +70,6 @@ cubic
 # Prob_Volume
 0.005
 200.0
-200.0
 
 # Prob_Swap
 0.195

--- a/Scripts/testSuite/Resources/exampleResources/GEMC/Diethylether/gemc_diethylether.inp
+++ b/Scripts/testSuite/Resources/exampleResources/GEMC/Diethylether/gemc_diethylether.inp
@@ -68,7 +68,6 @@ cubic
 # Prob_Volume
 0.005
 100.0
-100.0
 
 # Prob_Swap
 0.095

--- a/Scripts/testSuite/Resources/exampleResources/GEMC/Isobutane/gemc_isobutane.inp
+++ b/Scripts/testSuite/Resources/exampleResources/GEMC/Isobutane/gemc_isobutane.inp
@@ -70,7 +70,6 @@ cubic
 # Prob_Volume
 0.005
 200.0
-200.0
 
 # Prob_Swap
 0.195

--- a/Src/input_routines.f90
+++ b/Src/input_routines.f90
@@ -4353,7 +4353,7 @@ SUBROUTINE Get_Move_Probabilities
                     IF (box_list(ibox)%dv_max > 0.0_DP .AND. .NOT. l_cubic(ibox)) THEN
                        err_msg = ''
                        err_msg(1) = 'Volume change moves are only supported for cubic boxes'
-                       CALL Clean_Abort(err_msg,'Get_Move_Probabiltieis')
+                       CALL Clean_Abort(err_msg,'Get_Move_Probabilities')
                     END IF
 
                     WRITE(logunit,'(X,A,X,I2,X,A,X,F10.3,X,A)') &
@@ -4370,6 +4370,12 @@ SUBROUTINE Get_Move_Probabilities
               line_nbr = line_nbr + 1
               CALL Parse_String(inputunit,line_nbr,0,nbr_entries,line_array,ierr)
               IF ( nbr_entries > 0 ) THEN
+
+                 !TODO the current implementation of log volumes needs validation
+                 err_msg = ''
+                 err_msg(1) = 'Volume change moves are only supported for cubic boxes'
+                 CALL Clean_Abort(err_msg,'Get_Move_Probabilities')
+
                  vol_int = String_To_Int(line_array(1))
                  IF (vol_int == 1 ) THEN
                     ! volume move to be performed in log ratio

--- a/Src/input_routines.f90
+++ b/Src/input_routines.f90
@@ -4373,7 +4373,7 @@ SUBROUTINE Get_Move_Probabilities
 
                  !TODO the current implementation of log volumes needs validation
                  err_msg = ''
-                 err_msg(1) = 'Volume change moves are only supported for cubic boxes'
+                 err_msg(1) = 'Volume change moves in log space are not supported'
                  CALL Clean_Abort(err_msg,'Get_Move_Probabilities')
 
                  vol_int = String_To_Int(line_array(1))


### PR DESCRIPTION
The diethylether and isobutane GEMC examples had an extra line
after the maximum volume move parameter. This would trigger an
error due to code that would look at this line as a flag
to activate volume moves in log space.

Since log space volume moves were implemented too long ago, and the
code has changed since then, an error is thrown if the execution reaches
tihs point.

Most of the log volume move code looks good, but it has not been tested
yet.