### PR TITLE
Upgrade gcc and gfortran versions used for Azure Pipelines CI runs.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,6 +23,7 @@ jobs:
       Ubuntu-gcc-9:
         imageName: 'ubuntu-latest'
         python.version: 3.7
+        gcc.version: 'gcc-9'
         gfortran.version: 'gfortran-9'
         makefile.name: 'Makefile.gfortran'
         exec.name: 'cassandra_gfortran.exe'
@@ -30,21 +31,40 @@ jobs:
       Ubuntu-gcc-10:
         imageName: 'ubuntu-latest'
         python.version: 3.7
+        gcc.version: 'gcc-10'
         gfortran.version: 'gfortran-10'
         makefile.name: 'Makefile.gfortran'
         exec.name: 'cassandra_gfortran.exe'
         omp.num.threads: 1
-      Ubuntu-gcc-10-openMP:
+      Ubuntu-gcc-11:
         imageName: 'ubuntu-latest'
         python.version: 3.7
-        gfortran.version: 'gfortran-10'
+        gcc.version: 'gcc-11'
+        gfortran.version: 'gfortran-11'
+        makefile.name: 'Makefile.gfortran'
+        exec.name: 'cassandra_gfortran.exe'
+        omp.num.threads: 1
+      Ubuntu-gcc-12:
+        imageName: 'ubuntu-latest'
+        python.version: 3.7
+        gcc.version: 'gcc-12'
+        gfortran.version: 'gfortran-12'
+        makefile.name: 'Makefile.gfortran'
+        exec.name: 'cassandra_gfortran.exe'
+        omp.num.threads: 1
+      Ubuntu-gcc-12-openMP:
+        imageName: 'ubuntu-latest'
+        python.version: 3.7
+        gcc.version: 'gcc-12'
+        gfortran.version: 'gfortran-12'
         makefile.name: 'Makefile.gfortran.openMP'
         exec.name: 'cassandra_gfortran_openMP.exe'
         omp.num.threads: 8
-      macOS-gcc-10:
+      macOS-gcc-12:
         imageName: 'macOS-latest'
         python.version: 3.7
-        gfortran.version: 'gfortran-10'
+        gcc.version: 'gcc-12'
+        gfortran.version: 'gfortran-12'
         makefile.name: 'Makefile.gfortran'
         exec.name: 'cassandra_gfortran.exe'
         omp.num.threads: 1


### PR DESCRIPTION
## Description
See related issue.  The gcc version is also specified because C code is used in PR #141, which will probably be merged soon after this PR.

## Related Issue
Closes #144 

## How Has This Been Tested?
Azure pipelines CI runs now complete successfully.

## Backward Compatibility
There are no changes to backward compatibility.

## Post Submission Checklist
Please check the fields below as they are completed

- [x] My name is in the contributor list at `/Documentation/source/reference/acknowledgements.rst`
