### PR TITLE
Rb torsions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@
 # Prerequisites
 *.d
 
+# Optimization reports and assembly listings
+*.optrpt
+*.s
+
 # Compiled Object files
 *.slo
 *.lo

--- a/Src/Makefile
+++ b/Src/Makefile
@@ -95,7 +95,7 @@ OBJS =  main.o \
   mcf_control.o \
   nptmc_driver.o \
   create_nonbond_table.o \
-  get_internal_coords.o \
+  internal_coordinate_routines.o \
   clean_abort.o \
   move_translate.o \
   random_generators.o \

--- a/Src/Makefile.conda
+++ b/Src/Makefile.conda
@@ -86,7 +86,7 @@ OBJS =  main.o \
   mcf_control.o \
   nptmc_driver.o \
   create_nonbond_table.o \
-  get_internal_coords.o \
+  internal_coordinate_routines.o \
   clean_abort.o \
   move_translate.o \
   random_generators.o \

--- a/Src/Makefile.gfortran
+++ b/Src/Makefile.gfortran
@@ -87,7 +87,7 @@ OBJS =  main.o \
   mcf_control.o \
   nptmc_driver.o \
   create_nonbond_table.o \
-  get_internal_coords.o \
+  internal_coordinate_routines.o \
   clean_abort.o \
   move_translate.o \
   random_generators.o \

--- a/Src/Makefile.gfortran.openMP
+++ b/Src/Makefile.gfortran.openMP
@@ -86,7 +86,7 @@ OBJS =  main.o \
   mcf_control.o \
   nptmc_driver.o \
   create_nonbond_table.o \
-  get_internal_coords.o \
+  internal_coordinate_routines.o \
   clean_abort.o \
   move_translate.o \
   random_generators.o \

--- a/Src/Makefile.intel.openMP
+++ b/Src/Makefile.intel.openMP
@@ -87,7 +87,7 @@ OBJS =	main.o \
 	mcf_control.o \
 	nptmc_driver.o \
 	create_nonbond_table.o \
-	get_internal_coords.o \
+	internal_coordinate_routines.o \
 	clean_abort.o \
 	move_translate.o \
 	random_generators.o \

--- a/Src/Makefile.pgfortran
+++ b/Src/Makefile.pgfortran
@@ -86,7 +86,7 @@ OBJS = main.o \
        mcf_control.o \
        nptmc_driver.o \
        create_nonbond_table.o \
-       get_internal_coords.o \
+       internal_coordinate_routines.o \
        clean_abort.o \
        move_translate.o \
        random_generators.o \

--- a/Src/Makefile.pgfortran.openMP
+++ b/Src/Makefile.pgfortran.openMP
@@ -86,7 +86,7 @@ OBJS = main.o \
        mcf_control.o \
        nptmc_driver.o \
        create_nonbond_table.o \
-       get_internal_coords.o \
+       internal_coordinate_routines.o \
        clean_abort.o \
        move_translate.o \
        random_generators.o \

--- a/Src/atoms_to_place.f90
+++ b/Src/atoms_to_place.f90
@@ -108,8 +108,8 @@ CONTAINS
           IF (AllocateStatus /= 0 ) STOP
 
           ! identify atom1 and atom2 associated with global bond number ibonds in species ispecies
-          atom1 = bond_list(ibonds,ispecies)%atom1
-          atom2 = bond_list(ibonds,ispecies)%atom2
+          atom1 = bond_list(ibonds,ispecies)%atom(1)
+          atom2 = bond_list(ibonds,ispecies)%atom(2)
 
           ! initially set the total number of atoms to be placed equal to
           ! zero for both of these atoms
@@ -157,7 +157,7 @@ CONTAINS
           ! Since the identity of atom1 might have changed by recursive_placement routine. We
           ! determine the identity of atom1 once again.
 
-          atom1 = bond_list(ibonds,ispecies)%atom1
+          atom1 = bond_list(ibonds,ispecies)%atom(1)
 
           alive_atoms = 0
           alive = 0
@@ -266,9 +266,9 @@ CONTAINS
 
           ! determine the atoms that form iangles
 
-          atom1 = angle_list(iangles,ispecies)%atom1
-          atom2 = angle_list(iangles,ispecies)%atom2
-          atom3 = angle_list(iangles,ispecies)%atom3
+          atom1 = angle_list(iangles,ispecies)%atom(1)
+          atom2 = angle_list(iangles,ispecies)%atom(2)
+          atom3 = angle_list(iangles,ispecies)%atom(3)
 
           ! when the atoms, atom1 and all the atoms connected to it are regrown
           
@@ -284,7 +284,7 @@ CONTAINS
           ! since the identity of atom1 might have changed due to the recursive routine, we reset
           ! this identity
 
-          atom1 = angle_list(iangles,ispecies)%atom1
+          atom1 = angle_list(iangles,ispecies)%atom(1)
           
           ! assign all the atoms 
           
@@ -298,7 +298,7 @@ CONTAINS
           END DO
 
           ! Reassign the identity of atom1
-          atom1 = angle_list(iangles,ispecies)%atom1
+          atom1 = angle_list(iangles,ispecies)%atom(1)
           
           alive_atoms = 0
           atoms_to_place_list(:) = 0
@@ -430,10 +430,10 @@ CONTAINS
 
           ! obtain atoms in this dihedral
 
-          atom1 = dihedral_list(idihedrals,ispecies)%atom1
-          atom2 = dihedral_list(idihedrals,ispecies)%atom2
-          atom3 = dihedral_list(idihedrals,ispecies)%atom3
-          atom4 = dihedral_list(idihedrals,ispecies)%atom4
+          atom1 = dihedral_list(idihedrals,ispecies)%atom(1)
+          atom2 = dihedral_list(idihedrals,ispecies)%atom(2)
+          atom3 = dihedral_list(idihedrals,ispecies)%atom(3)
+          atom4 = dihedral_list(idihedrals,ispecies)%atom(4)
 
           ! now when the dihedral move affects atom1 and other atoms connected to atom1
 
@@ -469,7 +469,7 @@ CONTAINS
           ! now hold atom1, atom2 and atom3 fixed so that dihedral move affects atom4
           ! reassign the indentity of atom1
 
-          atom1 = dihedral_list(idihedrals,ispecies)%atom1
+          atom1 = dihedral_list(idihedrals,ispecies)%atom(1)
 
           alive_atoms = 0
           atoms_to_place_list(:) = 0
@@ -516,8 +516,8 @@ CONTAINS
        DO i = 1, nspecies
           DO j = 1,ndihedrals(i)
              write(logunit,*) 'dihedral, atom1, atom2, atom3, atom4'
-             write(logunit,*) j,dihedral_list(j,i)%atom1,dihedral_list(j,i)%atom2, dihedral_list(j,i)%atom3, &
-                  dihedral_list(j,i)%atom4
+             write(logunit,*) j,dihedral_list(j,i)%atom(1),dihedral_list(j,i)%atom(2), dihedral_list(j,i)%atom(3), &
+                  dihedral_list(j,i)%atom(4)
              write(logunit,*)
              write(logunit,*) 'natoms to place if atom 1 moves and the moving atom numbers'
              write(logunit,*) dihedral_atoms_to_place_list(j,i)%atom1_natoms, dihedral_atoms_to_place_list(j,i)%atom1
@@ -608,8 +608,8 @@ CONTAINS
           
           bond_i = bondpart_list(atomplaced,ispecies)%bond_num(i)
           
-          atom1i = bond_list(bond_i,ispecies)%atom1
-          atom2i = bond_list(bond_i,ispecies)%atom2
+          atom1i = bond_list(bond_i,ispecies)%atom(1)
+          atom2i = bond_list(bond_i,ispecies)%atom(2)
           
           IF ( atom1i == atomplaced ) THEN
              
@@ -651,8 +651,8 @@ CONTAINS
              bond_j = bondpart_list(atomplaced,ispecies)%bond_num(j)
              
              ! Now find the global atom numbers on either side of global bond number bond_j
-             atom1j = bond_list(bond_j,ispecies)%atom1
-             atom2j = bond_list(bond_j,ispecies)%atom2
+             atom1j = bond_list(bond_j,ispecies)%atom(1)
+             atom2j = bond_list(bond_j,ispecies)%atom(2)
              
              IF ( atom1j == atomplaced) THEN
                 
@@ -694,8 +694,8 @@ CONTAINS
           
           bond_j = bondpart_list(atomplaced,ispecies)%bond_num(j)
           
-          atom1j = bond_list(bond_j,ispecies)%atom1
-          atom2j = bond_list(bond_j,ispecies)%atom2
+          atom1j = bond_list(bond_j,ispecies)%atom(1)
+          atom2j = bond_list(bond_j,ispecies)%atom(2)
           
           IF (atom1j == atomplaced) THEN
              

--- a/Src/create_intra_exclusion_table.f90
+++ b/Src/create_intra_exclusion_table.f90
@@ -107,8 +107,8 @@ SUBROUTINE Create_Intra_Exclusion_Table
      !
 
      DO kk=1,ndihedrals(is)
-        ii = dihedral_list(kk,is)%atom1
-        jj = dihedral_list(kk,is)%atom4
+        ii = dihedral_list(kk,is)%atom(1)
+        jj = dihedral_list(kk,is)%atom(4)
 
         vdw_intra_scale(ii,jj,is) = scale_1_4_vdw(is)
         vdw_intra_scale(jj,ii,is) = scale_1_4_vdw(is)
@@ -121,8 +121,8 @@ SUBROUTINE Create_Intra_Exclusion_Table
      ! 1-3 scaling via angles
      DO kk = 1,nangles(is)
 
-        ii = angle_list(kk,is)%atom1
-        jj = angle_list(kk,is)%atom3
+        ii = angle_list(kk,is)%atom(1)
+        jj = angle_list(kk,is)%atom(3)
 
         vdw_intra_scale(ii,jj,is) = scale_1_3_vdw(is)
         vdw_intra_scale(jj,ii,is) = scale_1_3_vdw(is)
@@ -134,8 +134,8 @@ SUBROUTINE Create_Intra_Exclusion_Table
      ! 1-2 scaling via bonds     
      DO kk=1,nbonds(is)
 
-        ii = bond_list(kk,is)%atom1
-        jj = bond_list(kk,is)%atom2
+        ii = bond_list(kk,is)%atom(1)
+        jj = bond_list(kk,is)%atom(2)
 
         vdw_intra_scale(ii,jj,is) = scale_1_2_vdw(is)
         vdw_intra_scale(jj,ii,is) = scale_1_2_vdw(is)

--- a/Src/get_com.f90
+++ b/Src/get_com.f90
@@ -145,6 +145,7 @@ SUBROUTINE Get_Internal_Coordinates(alive,ispecies)
   
   USE Type_Definitions
   USE Global_Variables
+  USE Internal_Coordinate_Routines
   
   IMPLICIT NONE
   

--- a/Src/global_variables.f90
+++ b/Src/global_variables.f90
@@ -260,6 +260,7 @@ USE Type_Definitions
   INTEGER, PARAMETER :: int_harmonic = 3
   INTEGER, PARAMETER :: int_cvff = 4
   INTEGER, PARAMETER :: int_amber = 5
+  INTEGER, PARAMETER :: int_rb_torsion = 6
 
   ! Define integers for molecule type
   INTEGER, PARAMETER :: int_noexist = -1
@@ -284,7 +285,7 @@ USE Type_Definitions
   LOGICAL :: first_res_update, igas_flag
   INTEGER, DIMENSION(:), ALLOCATABLE :: max_molecules, natoms, nmol_start, nring_atoms, nexo_atoms
   INTEGER, DIMENSION(:), ALLOCATABLE :: nbonds, nangles, nangles_fixed
-  INTEGER, DIMENSION(:), ALLOCATABLE :: ndihedrals, nimpropers
+  INTEGER, DIMENSION(:), ALLOCATABLE :: ndihedrals, ndihedrals_rb, ndihedrals_uncombined, nimpropers
   INTEGER, DIMENSION(:), ALLOCATABLE :: nfragments, fragment_bonds
 
   ! array to hold the total number of molecules of each species in a given box
@@ -353,7 +354,7 @@ USE Type_Definitions
   TYPE(Angle_Class), DIMENSION(:,:), ALLOCATABLE, TARGET :: angle_list
 
   ! Array with dimensions (ndihedrals, nspecies)
-  TYPE(Dihedral_Class), DIMENSION(:,:), ALLOCATABLE, TARGET :: dihedral_list
+  TYPE(Dihedral_Class), DIMENSION(:,:), ALLOCATABLE, TARGET :: dihedral_list, uncombined_dihedral_list
 
   ! Array with dimensions (nimpropers, nspecies)
   TYPE(Improper_Class), DIMENSION(:,:), ALLOCATABLE, TARGET :: improper_list

--- a/Src/global_variables.f90
+++ b/Src/global_variables.f90
@@ -285,7 +285,7 @@ USE Type_Definitions
   LOGICAL :: first_res_update, igas_flag
   INTEGER, DIMENSION(:), ALLOCATABLE :: max_molecules, natoms, nmol_start, nring_atoms, nexo_atoms
   INTEGER, DIMENSION(:), ALLOCATABLE :: nbonds, nangles, nangles_fixed
-  INTEGER, DIMENSION(:), ALLOCATABLE :: ndihedrals, ndihedrals_rb, ndihedrals_uncombined, nimpropers
+  INTEGER, DIMENSION(:), ALLOCATABLE :: ndihedrals, nimpropers
   INTEGER, DIMENSION(:), ALLOCATABLE :: nfragments, fragment_bonds
 
   ! array to hold the total number of molecules of each species in a given box

--- a/Src/input_routines.f90
+++ b/Src/input_routines.f90
@@ -2191,7 +2191,7 @@ SUBROUTINE Get_Dihedral_Info(is)
                               rb_c(4) = 8.0_DP*signfactor*dihedral_param(1)
                               rb_c(2) = -rb_c(4)
                       CASE(5)
-                              ! works due to pentuple angle identity for cosine
+                              ! works due to quintuple angle identity for cosine
                               ! cos(5x) = 16*cos^5(x) - 20*cos^3(x) + 5*cos(x)
                               rb_c(0) = dihedral_param(1)
                               rb_c(1) = 5.0_DP*signfactor*dihedral_param(1)

--- a/Src/input_routines.f90
+++ b/Src/input_routines.f90
@@ -201,7 +201,7 @@ SUBROUTINE Get_Nspecies
      STOP
   END IF
 
-  ALLOCATE( ndihedrals(nspecies), nimpropers(nspecies), Stat = AllocateStatus )
+  ALLOCATE( ndihedrals(nspecies), ndihedrals_rb(nspecies), ndihedrals_uncombined(nspecies), nimpropers(nspecies), Stat=AllocateStatus)
   IF (AllocateStatus /= 0) THEN
      write(*,*)'memory could not be allocated for ndihedrals or nimpropers array'
      write(*,*)'stopping'
@@ -1237,6 +1237,13 @@ SUBROUTINE Get_Molecule_Info
      write(*,*)'stopping'
      STOP
   END IF
+  ALLOCATE( uncombined_dihedral_list(MAXVAL(ndihedrals), nspecies), Stat = AllocateStatus )
+  IF (AllocateStatus /= 0) THEN
+     write(*,*)'memory could not be allocated for dihedral_list array'
+     write(*,*)'stopping'
+     STOP
+  END IF
+  uncombined_dihedral_list%l_rb_formatted = .FALSE.
 
   ALLOCATE( improper_list(MAXVAL(nimpropers), nspecies), Stat = AllocateStatus )
   IF (AllocateStatus /= 0) THEN
@@ -1710,14 +1717,14 @@ SUBROUTINE Get_Bond_Info(is)
            ENDIF
 
            ! Assign appropriate values to list elements
-           bond_list(ib,is)%atom1 = String_To_Int(line_array(2))
-           bond_list(ib,is)%atom2 = String_To_Int(line_array(3))
+           bond_list(ib,is)%atom(1) = String_To_Int(line_array(2))
+           bond_list(ib,is)%atom(2) = String_To_Int(line_array(3))
            bond_list(ib,is)%bond_potential_type = line_array(4)
 
            IF (verbose_log) THEN
               WRITE(logunit,'(A,T25,I3,1x,I3)') 'Species and bond number', is,ib
-              WRITE(logunit,'(A,T25,I3)') ' atom1:',bond_list(ib,is)%atom1
-              WRITE(logunit,'(A,T25,I3)') ' atom2:',bond_list(ib,is)%atom2
+              WRITE(logunit,'(A,T25,I3)') ' atom1:',bond_list(ib,is)%atom(1)
+              WRITE(logunit,'(A,T25,I3)') ' atom2:',bond_list(ib,is)%atom(2)
               WRITE(logunit,'(A,T25,A)') ' bond type:',bond_list(ib,is)%bond_potential_type
            END IF
 
@@ -1857,16 +1864,16 @@ SUBROUTINE Get_Angle_Info(is)
            ENDIF
 
            ! Assign appropriate values to list elements
-           angle_list(iang,is)%atom1 = String_To_Int(line_array(2))
-           angle_list(iang,is)%atom2 = String_To_Int(line_array(3))
-           angle_list(iang,is)%atom3 = String_To_Int(line_array(4))
+           angle_list(iang,is)%atom(1) = String_To_Int(line_array(2))
+           angle_list(iang,is)%atom(2) = String_To_Int(line_array(3))
+           angle_list(iang,is)%atom(3) = String_To_Int(line_array(4))
            angle_list(iang,is)%angle_potential_type = line_array(5)
 
            IF (verbose_log) THEN
                    WRITE(logunit,'(A,T25,I3,1x,I3)') 'Species and angle number', is,iang
-                   WRITE(logunit,'(A,T25,I3)') ' atom1:',angle_list(iang,is)%atom1
-                   WRITE(logunit,'(A,T25,I3)') ' atom2:',angle_list(iang,is)%atom2
-                   WRITE(logunit,'(A,T25,I3)') ' atom3:',angle_list(iang,is)%atom3
+                   WRITE(logunit,'(A,T25,I3)') ' atom1:',angle_list(iang,is)%atom(1)
+                   WRITE(logunit,'(A,T25,I3)') ' atom2:',angle_list(iang,is)%atom(2)
+                   WRITE(logunit,'(A,T25,I3)') ' atom3:',angle_list(iang,is)%atom(3)
                    WRITE(logunit,'(A,T25,A)') ' angle type:',angle_list(iang,is)%angle_potential_type
            END IF
 
@@ -1975,8 +1982,13 @@ SUBROUTINE Get_Dihedral_Info(is)
 
   INTEGER, INTENT(IN) :: is
 
-  INTEGER :: ierr,line_nbr,nbr_entries, idihed
+  INTEGER :: ierr,line_nbr,nbr_entries, idihed, idihed_rb
   CHARACTER(STRING_LEN) :: line_string, line_array(60)
+  REAL(DP), DIMENSION(max_dihedral_params) :: dihedral_param
+  REAL(DP), DIMENSION(0:5) :: rb_c
+  REAL(DP) :: signfactor
+  INTEGER :: n_rb_dihedrals, n_combined_dihedrals, int_n, i_entry, i
+  INTEGER, DIMENSION(4) :: i_atoms, i_atoms_reversed, i_rb_atoms
 
 !******************************************************************************
   REWIND(molfile_unit)
@@ -2009,14 +2021,17 @@ SUBROUTINE Get_Dihedral_Info(is)
            IF (verbose_log) WRITE(logunit,*) 'No dihedrals in species ',is
            EXIT
         ENDIF
+        n_rb_dihedrals = 0
+        n_combined_dihedrals = 0
 
         DO idihed = 1,ndihedrals(is)
+           rb_c = 0.0_DP
            ! Now read the entries on the next lines. There must be at least 6 for
            ! each dihedral.
            line_nbr = line_nbr + 1
            CALL Parse_String(molfile_unit,line_nbr,6,nbr_entries,line_array,ierr)
 
-           ! Test for problems readin file
+           ! Test for problems reading file
            IF (ierr /= 0) THEN
               err_msg = ''
               err_msg(1) = "Error reading dihedral info."
@@ -2031,155 +2046,293 @@ SUBROUTINE Get_Dihedral_Info(is)
            ENDIF
 
            ! Assign appropriate values to list elements
-           dihedral_list(idihed,is)%atom1 = String_To_Int(line_array(2))
-           dihedral_list(idihed,is)%atom2 = String_To_Int(line_array(3))
-           dihedral_list(idihed,is)%atom3 = String_To_Int(line_array(4))
-           dihedral_list(idihed,is)%atom4 = String_To_Int(line_array(5))
+           uncombined_dihedral_list(idihed,is)%atom(1) = String_To_Int(line_array(2))
+           uncombined_dihedral_list(idihed,is)%atom(2) = String_To_Int(line_array(3))
+           uncombined_dihedral_list(idihed,is)%atom(3) = String_To_Int(line_array(4))
+           uncombined_dihedral_list(idihed,is)%atom(4) = String_To_Int(line_array(5))
 
-           dihedral_list(idihed,is)%dihedral_potential_type = line_array(6)
+           uncombined_dihedral_list(idihed,is)%dihedral_potential_type = line_array(6)
 
            IF (verbose_log) THEN
               WRITE(logunit,'(A,T25,I3,1x,I3)') 'Species and dihedral number', is,idihed
-              WRITE(logunit,'(A,T25,I3)') ' atom1:',dihedral_list(idihed,is)%atom1
-              WRITE(logunit,'(A,T25,I3)') ' atom2:',dihedral_list(idihed,is)%atom2
-              WRITE(logunit,'(A,T25,I3)') ' atom3:',dihedral_list(idihed,is)%atom3
-              WRITE(logunit,'(A,T25,I3)') ' atom4:',dihedral_list(idihed,is)%atom4
+              WRITE(logunit,'(A,T25,I3)') ' atom1:',uncombined_dihedral_list(idihed,is)%atom(1)
+              WRITE(logunit,'(A,T25,I3)') ' atom2:',uncombined_dihedral_list(idihed,is)%atom(2)
+              WRITE(logunit,'(A,T25,I3)') ' atom3:',uncombined_dihedral_list(idihed,is)%atom(3)
+              WRITE(logunit,'(A,T25,I3)') ' atom4:',uncombined_dihedral_list(idihed,is)%atom(4)
               WRITE(logunit,'(A,T25,A)') ' dihedral type:', &
-                dihedral_list(idihed,is)%dihedral_potential_type
+                uncombined_dihedral_list(idihed,is)%dihedral_potential_type
            END IF
 
            ! Load dihedral potential parameters, specific for each individual type
-           IF (dihedral_list(idihed,is)%dihedral_potential_type == 'OPLS') THEN
+           SELECT CASE(uncombined_dihedral_list(idihed,is)%dihedral_potential_type)
+           CASE('OPLS','opls')
+           !IF (uncombined_dihedral_list(idihed,is)%dihedral_potential_type == 'OPLS') THEN
 
-              dihedral_list(idihed,is)%int_dipot_type = int_opls
+              uncombined_dihedral_list(idihed,is)%int_dipot_type = int_opls
               !a0, a1, a2, a3 in kJ/mol
-              dihedral_list(idihed,is)%dihedral_param(1) = String_To_Double(line_array(7))
-              dihedral_list(idihed,is)%dihedral_param(2) = String_To_Double(line_array(8))
-              dihedral_list(idihed,is)%dihedral_param(3) = String_To_Double(line_array(9))
-              dihedral_list(idihed,is)%dihedral_param(4) = String_To_Double(line_array(10))
+              uncombined_dihedral_list(idihed,is)%dihedral_param(1) = String_To_Double(line_array(7))
+              uncombined_dihedral_list(idihed,is)%dihedral_param(2) = String_To_Double(line_array(8))
+              uncombined_dihedral_list(idihed,is)%dihedral_param(3) = String_To_Double(line_array(9))
+              uncombined_dihedral_list(idihed,is)%dihedral_param(4) = String_To_Double(line_array(10))
+              dihedral_param(1:4) = uncombined_dihedral_list(idihed,is)%dihedral_param(1:4)
 
               IF (verbose_log) THEN
                  WRITE(logunit,'(A,T25,F10.4)') ' a0, kJ/mol:', &
-                   dihedral_list(idihed,is)%dihedral_param(1)
+                   uncombined_dihedral_list(idihed,is)%dihedral_param(1)
                  WRITE(logunit,'(A,T25,F10.4)') ' a1, kJ/mol:', &
-                   dihedral_list(idihed,is)%dihedral_param(2)
+                   uncombined_dihedral_list(idihed,is)%dihedral_param(2)
                  WRITE(logunit,'(A,T25,F10.4)') ' a2, kJ/mol:', &
-                   dihedral_list(idihed,is)%dihedral_param(3)
+                   uncombined_dihedral_list(idihed,is)%dihedral_param(3)
                  WRITE(logunit,'(A,T25,F10.4)') ' a3, kJ/mol:', &
-                   dihedral_list(idihed,is)%dihedral_param(4)
+                   uncombined_dihedral_list(idihed,is)%dihedral_param(4)
               END IF
 
               ! Convert to molecular units amu A^2/ps^2
-              dihedral_list(idihed,is)%dihedral_param(1) = kjmol_to_atomic* dihedral_list(idihed,is)%dihedral_param(1)
-              dihedral_list(idihed,is)%dihedral_param(2) = kjmol_to_atomic* dihedral_list(idihed,is)%dihedral_param(2)
-              dihedral_list(idihed,is)%dihedral_param(3) = kjmol_to_atomic* dihedral_list(idihed,is)%dihedral_param(3)
-              dihedral_list(idihed,is)%dihedral_param(4) = kjmol_to_atomic* dihedral_list(idihed,is)%dihedral_param(4)
+              dihedral_param(1:4) = kjmol_to_atomic*dihedral_param(1:4)
+              uncombined_dihedral_list(idihed,is)%dihedral_param(1:4) = dihedral_param(1:4)
 
+              IF (ALL(ABS(dihedral_param(1:4)) < tiny_number)) THEN
+                      uncombined_dihedral_list(idihed,is)%int_dipot_type = int_none
+                      uncombined_dihedral_list(idihed,is)%dihedral_potential_type = 'NONE'
+              ELSE
+                      uncombined_dihedral_list(idihed,is)%l_rb_formatted = .TRUE.
+                      rb_c = 0.0_DP
+                      rb_c(0) = dihedral_param(3) + SUM(dihedral_param(1:4))
+                      rb_c(1) = dihedral_param(2) - 3.0_DP*dihedral_param(4)
+                      rb_c(2) = -2.0_DP*dihedral_param(3)
+                      rb_c(3) = 4.0_DP*dihedral_param(4)
+              END IF
 
-           ELSE IF (dihedral_list(idihed,is)%dihedral_potential_type == 'CHARMM') THEN
-              dihedral_list(idihed,is)%int_dipot_type = int_charmm
-              dihedral_list(idihed,is)%dihedral_param(1) = String_To_Double(line_array(7))
-              dihedral_list(idihed,is)%dihedral_param(2) = String_To_Double(line_array(8))
-              dihedral_list(idihed,is)%dihedral_param(3) = String_To_Double(line_array(9))
+           CASE('RB','rb', 'Ryckaert-Bellemans')
+           !ELSE IF (uncombined_dihedral_list(idihed,is)%dihedral_potential_type == 'RB') THEN
+                uncombined_dihedral_list(idihed,is)%int_dipot_type = int_rb_torsion
+                dihedral_param(1:6) = 0.0_DP
+                DO i = 1, 6
+                        i_entry = i + 6
+                        IF (i_entry > nbr_entries) EXIT
+                        dihedral_param(i) = String_To_Double(line_array(i_entry))
+                        IF (verbose_log) THEN
+                                WRITE(logunit,'(A2,I1,A9,T25,F10.4)') ' c', i-1, ', kJ/mol:', &
+                                        dihedral_param(i)
+                        END IF
+                END DO
+                IF (ALL(ABS(dihedral_param(1:6))<tiny_number)) THEN
+                        uncombined_dihedral_list(idihed,is)%int_dipot_type = int_none
+                        uncombined_dihedral_list(idihed,is)%dihedral_potential_type = 'NONE'
+                ELSE
+                        rb_c = dihedral_param(1:6) * kjmol_to_atomic
+                        uncombined_dihedral_list(idihed,is)%l_rb_formatted = .TRUE.
+                END IF
+
+           CASE('CHARMM','charmm')
+           !ELSE IF (uncombined_dihedral_list(idihed,is)%dihedral_potential_type == 'CHARMM') THEN
+              uncombined_dihedral_list(idihed,is)%int_dipot_type = int_charmm
+              dihedral_param(1) = String_To_Double(line_array(7))
+              dihedral_param(2) = String_To_Double(line_array(8))
+              dihedral_param(3) = String_To_Double(line_array(9))
+              IF (ABS(ABS(dihedral_param(3))-180.0_DP) < tiny_number .AND. ABS(dihedral_param(2))<tiny_number) THEN
+                      dihedral_param(1) = 0.0_DP
+              END IF
               !
 
               IF (verbose_log) THEN
                  WRITE(logunit,'(A,T25,F10.4)') ' a0, kJ/mol:', &
-                      dihedral_list(idihed,is)%dihedral_param(1)
+                      dihedral_param(1)
                  WRITE(logunit,'(A,T25,F10.4)') ' n ', &
-                      dihedral_list(idihed,is)%dihedral_param(2)
+                      dihedral_param(2)
                  WRITE(logunit,'(A,T25,F10.4)') 'delta', &
-                      dihedral_list(idihed,is)%dihedral_param(3)
+                      dihedral_param(3)
+              END IF
+              ! cos(±x) = cos(x)
+              int_n = NINT(dihedral_param(2))
+              ! cos(±x ± 180°) = -cos(x)
+              IF (ABS(ABS(dihedral_param(3))-180.0_DP) < tiny_number) THEN
+                      signfactor = -1.0_DP
+              ELSE IF (ABS(dihedral_param(3))<tiny_number) THEN
+                      signfactor = 1.0_DP
+              ELSE
+                      signfactor = 0.0_DP
               END IF
 
 
               ! Convert to molecular units amu A^2/ps^2 and the delta
               ! parameter to radians
-              dihedral_list(idihed,is)%dihedral_param(1) = kjmol_to_atomic* dihedral_list(idihed,is)%dihedral_param(1)
-              dihedral_list(idihed,is)%dihedral_param(3) = (PI/180.0_DP)* dihedral_list(idihed,is)%dihedral_param(3)
-
-!AV: AMBER style for dihedral multiplicity, cf. Zhong et al. JpcB, 115, 10027, 2011.
-!Note that I assumed the maximum # of dihedral multiplicity is 3 and tried to avoide a 2-dimensional arrays.
-           ELSE IF (dihedral_list(idihed,is)%dihedral_potential_type == 'AMBER') THEN
-              dihedral_list(idihed,is)%int_dipot_type = int_amber
-              dihedral_list(idihed,is)%dihedral_param(1) = String_To_Double(line_array(7))
-              dihedral_list(idihed,is)%dihedral_param(2) = String_To_Double(line_array(8))
-              dihedral_list(idihed,is)%dihedral_param(3) = String_To_Double(line_array(9))
-              dihedral_list(idihed,is)%dihedral_param(4) = String_To_Double(line_array(10))
-              dihedral_list(idihed,is)%dihedral_param(5) = String_To_Double(line_array(11))
-              dihedral_list(idihed,is)%dihedral_param(6) = String_To_Double(line_array(12))
-              dihedral_list(idihed,is)%dihedral_param(7) = String_To_Double(line_array(13))
-              dihedral_list(idihed,is)%dihedral_param(8) = String_To_Double(line_array(14))
-              dihedral_list(idihed,is)%dihedral_param(9) = String_To_Double(line_array(15))
-              !AV: commented out b/c 3 terms is usually enough.
-              !dihedral_list(idihed,is)%dihedral_param(10) = String_To_Double(line_array(16))
-              !dihedral_list(idihed,is)%dihedral_param(11) = String_To_Double(line_array(17))
-              !dihedral_list(idihed,is)%dihedral_param(12) = String_To_Double(line_array(18))
-
-              !
-
-              IF (verbose_log) THEN
-                 WRITE(logunit,'(A,T25,F10.4)') ' a01, kJ/mol:', &
-                   dihedral_list(idihed,is)%dihedral_param(1)
-                 WRITE(logunit,'(A,T25,F10.4)') ' n1 ', &
-                   dihedral_list(idihed,is)%dihedral_param(2)
-                 WRITE(logunit,'(A,T25,F10.4)') 'delta1', &
-                   dihedral_list(idihed,is)%dihedral_param(3)
-                 WRITE(logunit,'(A,T25,F10.4)') ' a02, kJ/mol:', &
-                   dihedral_list(idihed,is)%dihedral_param(4)
-                 WRITE(logunit,'(A,T25,F10.4)') ' n2 ', &
-                   dihedral_list(idihed,is)%dihedral_param(5)
-                 WRITE(logunit,'(A,T25,F10.4)') 'delta2', &
-                   dihedral_list(idihed,is)%dihedral_param(6)
-                 WRITE(logunit,'(A,T25,F10.4)') ' a03, kJ/mol:', &
-                   dihedral_list(idihed,is)%dihedral_param(7)
-                 WRITE(logunit,'(A,T25,F10.4)') ' n3 ', &
-                   dihedral_list(idihed,is)%dihedral_param(8)
-                 WRITE(logunit,'(A,T25,F10.4)') 'delta3', &
-                   dihedral_list(idihed,is)%dihedral_param(9)
+              dihedral_param(1) = kjmol_to_atomic* dihedral_param(1)
+              dihedral_param(3) = (PI/180.0_DP)* dihedral_param(3)
+              uncombined_dihedral_list(idihed,is)%dihedral_param(1:3) = dihedral_param(1:3)
+              IF (ABS(dihedral_param(1)) < tiny_number) THEN
+                      uncombined_dihedral_list(idihed,is)%int_dipot_type = int_none
+                      uncombined_dihedral_list(idihed,is)%dihedral_potential_type = 'NONE'
+              ELSE IF (ABS(REAL(int_n,DP) - dihedral_param(2))<tiny_number .AND. signfactor .NE. 0.0_DP) THEN
+                      uncombined_dihedral_list(idihed,is)%l_rb_formatted = .TRUE.
+                      int_n = ABS(int_n)
+                      SELECT CASE(int_n)
+                      CASE(0)
+                              rb_c(0) = (1.0_DP+signfactor)*dihedral_param(1)
+                      CASE(1)
+                              rb_c(0) = dihedral_param(1)
+                              rb_c(1) = signfactor*dihedral_param(1)
+                      CASE(2)
+                              ! works due to double angle identity for cosine
+                              rb_c(0) = (1.0_DP-signfactor)*dihedral_param(1)
+                              rb_c(2) = 2.0_DP*signfactor*dihedral_param(1)
+                      CASE(3)
+                              ! works due to triple angle identity for cosine
+                              rb_c(0) = dihedral_param(1)
+                              rb_c(1) = -3.0_DP*signfactor*dihedral_param(1)
+                              rb_c(3) = 4.0_DP*signfactor*dihedral_param(1)
+                      CASE(4)
+                              ! works due to quadruple angle identity for cosine
+                              ! cos(4x) = 8*cos^4(x) - 8*cos^2(x) + 1
+                              rb_c(0) = (1.0_DP+signfactor)*dihedral_param(1)
+                              rb_c(4) = 8.0_DP*signfactor*dihedral_param(1)
+                              rb_c(2) = -rb_c(4)
+                      CASE(5)
+                              ! works due to pentuple angle identity for cosine
+                              ! cos(5x) = 16*cos^5(x) - 20*cos^3(x) + 5*cos(x)
+                              rb_c(0) = dihedral_param(1)
+                              rb_c(1) = 5.0_DP*signfactor*dihedral_param(1)
+                              rb_c(3) = -20.0_DP*signfactor*dihedral_param(1)
+                              rb_c(5) = 16.0_DP*signfactor*dihedral_param(1)
+                      CASE DEFAULT
+                              uncombined_dihedral_list(idihed,is)%l_rb_formatted = .FALSE.
+                      END SELECT
+                      IF (ALL(ABS(rb_c)<tiny_number) .AND. uncombined_dihedral_list(idihed,is)%l_rb_formatted) THEN
+                              uncombined_dihedral_list(idihed,is)%l_rb_formatted = .FALSE.
+                              uncombined_dihedral_list(idihed,is)%int_dipot_type = int_none
+                              uncombined_dihedral_list(idihed,is)%dihedral_potential_type = 'NONE'
+                      END IF
               END IF
 
-              ! Convert to molecular units amu A^2/ps^2 and the delta
-              ! parameter to radians
-              dihedral_list(idihed,is)%dihedral_param(1) = kjmol_to_atomic* dihedral_list(idihed,is)%dihedral_param(1)
-              dihedral_list(idihed,is)%dihedral_param(4) = kjmol_to_atomic* dihedral_list(idihed,is)%dihedral_param(4)
-              dihedral_list(idihed,is)%dihedral_param(7) = kjmol_to_atomic* dihedral_list(idihed,is)%dihedral_param(7)
-              dihedral_list(idihed,is)%dihedral_param(3) = (PI/180.0_DP)* dihedral_list(idihed,is)%dihedral_param(3)
-              dihedral_list(idihed,is)%dihedral_param(6) = (PI/180.0_DP)* dihedral_list(idihed,is)%dihedral_param(6)
-              dihedral_list(idihed,is)%dihedral_param(9) = (PI/180.0_DP)* dihedral_list(idihed,is)%dihedral_param(9)
+              ! RS: I commented out the AMBER dihedral part below because it's a dead end. AV supposedly
+              !     implemented AMBER style dihedrals but they aren't dealt with anywhere else in the code,
+              !     except for when writing ring fragment mcf files, which just writes this info out again.
+              !     Until someone actually adds a way to use AMBER style dihedrals, specifying this type of
+              !     dihedral should cause an error message.  I also made it compatible with SELECT CASE instead of IF.
 
-           ELSE IF (dihedral_list(idihed,is)%dihedral_potential_type == 'harmonic') THEN
-              dihedral_list(idihed,is)%int_dipot_type = int_harmonic
+!!AV: AMBER style for dihedral multiplicity, cf. Zhong et al. JpcB, 115, 10027, 2011.
+!!Note that I assumed the maximum # of dihedral multiplicity is 3 and tried to avoide a 2-dimensional arrays.
+!           CASE('AMBER','amber')
+!           !ELSE IF (uncombined_dihedral_list(idihed,is)%dihedral_potential_type == 'AMBER') THEN
+!              uncombined_dihedral_list(idihed,is)%int_dipot_type = int_amber
+!              uncombined_dihedral_list(idihed,is)%dihedral_param(1) = String_To_Double(line_array(7))
+!              uncombined_dihedral_list(idihed,is)%dihedral_param(2) = String_To_Double(line_array(8))
+!              uncombined_dihedral_list(idihed,is)%dihedral_param(3) = String_To_Double(line_array(9))
+!              uncombined_dihedral_list(idihed,is)%dihedral_param(4) = String_To_Double(line_array(10))
+!              uncombined_dihedral_list(idihed,is)%dihedral_param(5) = String_To_Double(line_array(11))
+!              uncombined_dihedral_list(idihed,is)%dihedral_param(6) = String_To_Double(line_array(12))
+!              uncombined_dihedral_list(idihed,is)%dihedral_param(7) = String_To_Double(line_array(13))
+!              uncombined_dihedral_list(idihed,is)%dihedral_param(8) = String_To_Double(line_array(14))
+!              uncombined_dihedral_list(idihed,is)%dihedral_param(9) = String_To_Double(line_array(15))
+!              !AV: commented out b/c 3 terms is usually enough.
+!              !uncombined_dihedral_list(idihed,is)%dihedral_param(10) = String_To_Double(line_array(16))
+!              !uncombined_dihedral_list(idihed,is)%dihedral_param(11) = String_To_Double(line_array(17))
+!              !uncombined_dihedral_list(idihed,is)%dihedral_param(12) = String_To_Double(line_array(18))
+!
+!              !
+!
+!              IF (verbose_log) THEN
+!                 WRITE(logunit,'(A,T25,F10.4)') ' a01, kJ/mol:', &
+!                   uncombined_dihedral_list(idihed,is)%dihedral_param(1)
+!                 WRITE(logunit,'(A,T25,F10.4)') ' n1 ', &
+!                   uncombined_dihedral_list(idihed,is)%dihedral_param(2)
+!                 WRITE(logunit,'(A,T25,F10.4)') 'delta1', &
+!                   uncombined_dihedral_list(idihed,is)%dihedral_param(3)
+!                 WRITE(logunit,'(A,T25,F10.4)') ' a02, kJ/mol:', &
+!                   uncombined_dihedral_list(idihed,is)%dihedral_param(4)
+!                 WRITE(logunit,'(A,T25,F10.4)') ' n2 ', &
+!                   uncombined_dihedral_list(idihed,is)%dihedral_param(5)
+!                 WRITE(logunit,'(A,T25,F10.4)') 'delta2', &
+!                   uncombined_dihedral_list(idihed,is)%dihedral_param(6)
+!                 WRITE(logunit,'(A,T25,F10.4)') ' a03, kJ/mol:', &
+!                   uncombined_dihedral_list(idihed,is)%dihedral_param(7)
+!                 WRITE(logunit,'(A,T25,F10.4)') ' n3 ', &
+!                   uncombined_dihedral_list(idihed,is)%dihedral_param(8)
+!                 WRITE(logunit,'(A,T25,F10.4)') 'delta3', &
+!                   uncombined_dihedral_list(idihed,is)%dihedral_param(9)
+!              END IF
+!
+!              ! Convert to molecular units amu A^2/ps^2 and the delta
+!              ! parameter to radians
+!              uncombined_dihedral_list(idihed,is)%dihedral_param(1) = kjmol_to_atomic* uncombined_dihedral_list(idihed,is)%dihedral_param(1)
+!              uncombined_dihedral_list(idihed,is)%dihedral_param(4) = kjmol_to_atomic* uncombined_dihedral_list(idihed,is)%dihedral_param(4)
+!              uncombined_dihedral_list(idihed,is)%dihedral_param(7) = kjmol_to_atomic* uncombined_dihedral_list(idihed,is)%dihedral_param(7)
+!              uncombined_dihedral_list(idihed,is)%dihedral_param(3) = (PI/180.0_DP)* uncombined_dihedral_list(idihed,is)%dihedral_param(3)
+!              uncombined_dihedral_list(idihed,is)%dihedral_param(6) = (PI/180.0_DP)* uncombined_dihedral_list(idihed,is)%dihedral_param(6)
+!              uncombined_dihedral_list(idihed,is)%dihedral_param(9) = (PI/180.0_DP)* uncombined_dihedral_list(idihed,is)%dihedral_param(9)
+
+           CASE('HARMONIC','harmonic')
+           !ELSE IF (uncombined_dihedral_list(idihed,is)%dihedral_potential_type == 'harmonic') THEN
+              uncombined_dihedral_list(idihed,is)%int_dipot_type = int_harmonic
               ! d0 read in in units ofin K/radians^2 read in
-              dihedral_list(idihed,is)%dihedral_param(1) = String_To_Double(line_array(7))
+              uncombined_dihedral_list(idihed,is)%dihedral_param(1) = String_To_Double(line_array(7))
               ! theta0 in degrees
-              dihedral_list(idihed,is)%dihedral_param(2) = String_To_Double(line_array(8))
+              uncombined_dihedral_list(idihed,is)%dihedral_param(2) = String_To_Double(line_array(8))
 
 
               IF (verbose_log) THEN
                  WRITE(logunit,'(A,T25,F10.4)') ' Do_angle in K/rad^2:', &
-                   dihedral_list(idihed,is)%dihedral_param(1)
+                   uncombined_dihedral_list(idihed,is)%dihedral_param(1)
                  WRITE(logunit,'(A,T25,F10.4)') ' theta0 in degrees:', &
-                   dihedral_list(idihed,is)%dihedral_param(2)
+                   uncombined_dihedral_list(idihed,is)%dihedral_param(2)
               END IF
               ! Convert force constant to atomic units amu A^2/(rad^2 ps^2)
               ! so that Edihedral = amu A^2/ps^2v
-              dihedral_list(idihed,is)%dihedral_param(1) = kboltz * dihedral_list(idihed,is)%dihedral_param(1)
+              uncombined_dihedral_list(idihed,is)%dihedral_param(1) = kboltz * uncombined_dihedral_list(idihed,is)%dihedral_param(1)
 
               ! Convert the nominal bond angle to radians
-              dihedral_list(idihed,is)%dihedral_param(2) = (PI/180.0_DP)*dihedral_list(idihed,is)%dihedral_param(2)
+              uncombined_dihedral_list(idihed,is)%dihedral_param(2) = (PI/180.0_DP)*uncombined_dihedral_list(idihed,is)%dihedral_param(2)
+              IF (ABS(uncombined_dihedral_list(idihed,is)%dihedral_param(1)) < tiny_number) THEN
+                      uncombined_dihedral_list(idihed,is)%int_dipot_type = int_none
+                      uncombined_dihedral_list(idihed,is)%dihedral_potential_type = 'NONE'
+              END IF
 
 
-           ELSEIF (dihedral_list(idihed,is)%dihedral_potential_type == 'none') THEN
-              dihedral_list(idihed,is)%int_dipot_type = int_none
+           CASE('NONE','none')
+           !ELSEIF (uncombined_dihedral_list(idihed,is)%dihedral_potential_type == 'none') THEN
+              uncombined_dihedral_list(idihed,is)%int_dipot_type = int_none
 
-           ELSE
+           CASE DEFAULT
+           !ELSE
               err_msg = ''
               err_msg(1) = 'dihedral_potential type improperly specified in mcf file'
               CALL Clean_Abort(err_msg,'Get_Dihedral_Info')
-           ENDIF
+           END SELECT
+           !ENDIF
+           uncombined_dihedral_list(idihed,is)%rb_c = rb_c
+           IF (uncombined_dihedral_list(idihed,is)%l_rb_formatted) THEN
+                   i_atoms = uncombined_dihedral_list(idihed,is)%atom(:)
+                   i_atoms_reversed = i_atoms(4:1:-1)
+                   ! nothing needs to be changed if the dihedral atom order is reversed because the sign of phi
+                   !      doesn't matter for dihedrals formatted as RB torsions since cos(-x) = cos(x)
+                   DO idihed_rb = 1, n_rb_dihedrals
+                        i_rb_atoms = dihedral_list(idihed_rb,is)%atom(:)
+                        IF (ALL(i_atoms .EQ. i_rb_atoms) .OR. ALL(i_atoms_reversed .EQ. i_rb_atoms)) THEN
+                                dihedral_list(idihed_rb,is)%rb_c = &
+                                        dihedral_list(idihed_rb,is)%rb_c + rb_c
+                                EXIT
+                        END IF
+                   END DO
+                   IF (idihed_rb > n_rb_dihedrals) THEN
+                           dihedral_list(idihed_rb,is) = uncombined_dihedral_list(idihed,is)
+                           dihedral_list(idihed_rb,is)%dihedral_potential_type = 'RB torsion'
+                           dihedral_list(idihed_rb,is)%int_dipot_type = int_rb_torsion
+                           n_rb_dihedrals = idihed_rb
+                   END IF
+           END IF
 
         ENDDO
+        ndihedrals_rb(is) = n_rb_dihedrals
+        n_combined_dihedrals = n_rb_dihedrals
+        DO idihed = 1, ndihedrals(is)
+                IF (.NOT. uncombined_dihedral_list(idihed,is)%l_rb_formatted) THEN
+                        n_combined_dihedrals = n_combined_dihedrals + 1
+                        dihedral_list(n_combined_dihedrals,is) = &
+                                uncombined_dihedral_list(idihed,is)
+                END IF
+        END DO
+        ndihedrals_uncombined(is) = ndihedrals(is)
+        ndihedrals(is) = n_combined_dihedrals
 
         EXIT
 
@@ -2260,19 +2413,19 @@ INTEGER, INTENT(IN) :: is
            ENDIF
 
            ! Assign appropriate values to list elements
-           improper_list(iimprop,is)%atom1 = String_To_Int(line_array(2))
-           improper_list(iimprop,is)%atom2 = String_To_Int(line_array(3))
-           improper_list(iimprop,is)%atom3 = String_To_Int(line_array(4))
-           improper_list(iimprop,is)%atom4 = String_To_Int(line_array(5))
+           improper_list(iimprop,is)%atom(1) = String_To_Int(line_array(2))
+           improper_list(iimprop,is)%atom(2) = String_To_Int(line_array(3))
+           improper_list(iimprop,is)%atom(3) = String_To_Int(line_array(4))
+           improper_list(iimprop,is)%atom(4) = String_To_Int(line_array(5))
 
            improper_list(iimprop,is)%improper_potential_type = line_array(6)
 
            IF (verbose_log) THEN
                    WRITE(logunit,'(A,T25,I3,1x,I3)') 'Species and improper number', is,iimprop
-                   WRITE(logunit,'(A,T25,I3)') ' atom1:',improper_list(iimprop,is)%atom1
-                   WRITE(logunit,'(A,T25,I3)') ' atom2:',improper_list(iimprop,is)%atom2
-                   WRITE(logunit,'(A,T25,I3)') ' atom3:',improper_list(iimprop,is)%atom3
-                   WRITE(logunit,'(A,T25,I3)') ' atom4:',improper_list(iimprop,is)%atom4
+                   WRITE(logunit,'(A,T25,I3)') ' atom1:',improper_list(iimprop,is)%atom(1)
+                   WRITE(logunit,'(A,T25,I3)') ' atom2:',improper_list(iimprop,is)%atom(2)
+                   WRITE(logunit,'(A,T25,I3)') ' atom3:',improper_list(iimprop,is)%atom(3)
+                   WRITE(logunit,'(A,T25,I3)') ' atom4:',improper_list(iimprop,is)%atom(4)
                    WRITE(logunit,'(A,T25,A)') ' dihedral type:', &
                 improper_list(iimprop,is)%improper_potential_type
            END IF
@@ -2324,8 +2477,8 @@ INTEGER, INTENT(IN) :: is
               IF (verbose_log) THEN
               WRITE(logunit,'(A,4(I6,1x),A,I4)') &
                    'No improper potential between atoms: ',&
-                   improper_list(iimprop,is)%atom1, improper_list(iimprop,is)%atom2, &
-                   improper_list(iimprop,is)%atom3, improper_list(iimprop,is)%atom4, &
+                   improper_list(iimprop,is)%atom(1), improper_list(iimprop,is)%atom(2), &
+                   improper_list(iimprop,is)%atom(3), improper_list(iimprop,is)%atom(4), &
                    'in species', is
               END IF
 
@@ -2614,8 +2767,8 @@ SUBROUTINE Get_Fragment_Info(is)
 
               DO ibonds = 1, nbonds(is)
 
-                 atom1 = bond_list(ibonds,is)%atom1
-                 atom2 = bond_list(ibonds,is)%atom2
+                 atom1 = bond_list(ibonds,is)%atom(1)
+                 atom2 = bond_list(ibonds,is)%atom(2)
 
                  IF (i_atom == atom1 .AND. j_atom == atom2) &
                       iatoms_bond = iatoms_bond + 1

--- a/Src/load_next_frame.f90
+++ b/Src/load_next_frame.f90
@@ -12,6 +12,7 @@ SUBROUTINE Load_Next_Frame(end_reached)
         USE Simulation_Properties
         USE IO_Utilities
         USE Energy_Routines
+        USE Internal_Coordinate_Routines
         !$ USE OMP_LIB
 
         IMPLICIT NONE

--- a/Src/main.f90
+++ b/Src/main.f90
@@ -82,6 +82,7 @@ PROGRAM Main
   USE Energy_Routines
   USE Simulation_Properties
   USE Fragment_Growth
+  USE Internal_Coordinate_Routines
 
   IMPLICIT NONE
 

--- a/Src/move_angle.f90
+++ b/Src/move_angle.f90
@@ -201,9 +201,9 @@ SUBROUTINE Angle_Distortion
 !  CALL Get_Internal_Coordinates(lm,is)
 
   ! determine the atoms that define the angle
-  atom1 = angle_list(angle_to_move,is)%atom1
-  atom2 = angle_list(angle_to_move,is)%atom2
-  atom3 = angle_list(angle_to_move,is)%atom3
+  atom1 = angle_list(angle_to_move,is)%atom(1)
+  atom2 = angle_list(angle_to_move,is)%atom(2)
+  atom3 = angle_list(angle_to_move,is)%atom(3)
 
   ! We first determine the angle before the move and also the probability of observing this
   ! angle. 

--- a/Src/move_dihedral.f90
+++ b/Src/move_dihedral.f90
@@ -228,10 +228,10 @@ SUBROUTINE Rotate_Dihedral
   dihedral_to_move = INT( rranf() * ndihedrals(is) ) + 1
 
   ! Determine the atoms that form the dihedral to move
-  atom1 = dihedral_list(dihedral_to_move,is)%atom1
-  atom2 = dihedral_list(dihedral_to_move,is)%atom2
-  atom3 = dihedral_list(dihedral_to_move,is)%atom3
-  atom4 = dihedral_list(dihedral_to_move,is)%atom4
+  atom1 = dihedral_list(dihedral_to_move,is)%atom(1)
+  atom2 = dihedral_list(dihedral_to_move,is)%atom(2)
+  atom3 = dihedral_list(dihedral_to_move,is)%atom(3)
+  atom4 = dihedral_list(dihedral_to_move,is)%atom(4)
 
   
   IF (.NOT. ALLOCATED(atoms_to_place_list)) ALLOCATE(atoms_to_place_list(MAXVAL(natoms)),Stat=AllocateStatus)

--- a/Src/move_ring_flip.f90
+++ b/Src/move_ring_flip.f90
@@ -107,8 +107,8 @@ SUBROUTINE Flip_Move
         
         ! check if other atoms are ring atoms
 
-        atom1 = angle_list(angle_id,is)%atom1
-        atom2 = angle_list(angle_id,is)%atom3
+        atom1 = angle_list(angle_id,is)%atom(1)
+        atom2 = angle_list(angle_id,is)%atom(3)
 
         IF (nonbond_list(atom1,is)%ring_atom .AND. nonbond_list(atom2,is)%ring_atom) EXIT
 

--- a/Src/participation.f90
+++ b/Src/participation.f90
@@ -102,8 +102,8 @@ SUBROUTINE Participation
 
   DO is = 1,nspecies
      DO ibonds = 1,nbonds(is)
-        iatom = bond_list(ibonds,is)%atom1
-        jatom = bond_list(ibonds,is)%atom2
+        iatom = bond_list(ibonds,is)%atom(1)
+        jatom = bond_list(ibonds,is)%atom(2)
         l_bonded(iatom,jatom,is)=.true.
         l_bonded(jatom,iatom,is)=.true.
      ENDDO       
@@ -141,8 +141,8 @@ SUBROUTINE Participation
 
         DO ibonds = 1, nbonds(is)
            
-           atom1 = bond_list(ibonds,is)%atom1
-           atom2 = bond_list(ibonds,is)%atom2
+           atom1 = bond_list(ibonds,is)%atom(1)
+           atom2 = bond_list(ibonds,is)%atom(2)
 
            IF (atom1 == iatom .OR. atom2 == iatom) THEN
 
@@ -281,9 +281,9 @@ SUBROUTINE Participation
 
            ! obtain three atoms that define the angle
 
-           atom1 = angle_list(iangles,is)%atom1
-           atom2 = angle_list(iangles,is)%atom2
-           atom3 = angle_list(iangles,is)%atom3
+           atom1 = angle_list(iangles,is)%atom(1)
+           atom2 = angle_list(iangles,is)%atom(2)
+           atom3 = angle_list(iangles,is)%atom(3)
 
            IF ( iatom == atom1 ) THEN
 
@@ -390,10 +390,10 @@ SUBROUTINE Participation
 
            ! get the four atoms in the dihedral
 
-           atom1 = dihedral_list(idihedral,is)%atom1
-           atom2 = dihedral_list(idihedral,is)%atom2
-           atom3 = dihedral_list(idihedral,is)%atom3
-           atom4 = dihedral_list(idihedral,is)%atom4
+           atom1 = dihedral_list(idihedral,is)%atom(1)
+           atom2 = dihedral_list(idihedral,is)%atom(2)
+           atom3 = dihedral_list(idihedral,is)%atom(3)
+           atom4 = dihedral_list(idihedral,is)%atom(4)
 
            IF ( iatom == atom1 ) THEN
 
@@ -744,8 +744,8 @@ SUBROUTINE Participation
                     
                     this_angle = angle_part_list(ia,is)%which_angle(i)
                     
-                    first_atom = angle_list(this_angle,is)%atom1
-                    third_atom = angle_list(this_angle,is)%atom3
+                    first_atom = angle_list(this_angle,is)%atom(1)
+                    third_atom = angle_list(this_angle,is)%atom(3)
                     
                     DO j = 1, bondpart_list(ia,is)%nbonds
                        
@@ -986,9 +986,9 @@ CONTAINS
 
              this_angle = angle_part_list(this_atom,is)%which_angle(j)
 
-             first_atom = angle_list(this_angle,is)%atom1
-             second_atom = angle_list(this_angle,is)%atom2
-             third_atom = angle_list(this_angle,is)%atom3
+             first_atom = angle_list(this_angle,is)%atom(1)
+             second_atom = angle_list(this_angle,is)%atom(2)
+             third_atom = angle_list(this_angle,is)%atom(3)
 
              ! Now look for these two atoms in the fragment list to find their
              ! local id
@@ -1057,7 +1057,7 @@ CONTAINS
   !--------------------------------------------------------------------------------------------
   SUBROUTINE Write_Ring_Fragment_MCF_Dihedral_Info(ifrag,is)
     !------------------------------------------------------------------------------------------
-    ! Write the '# Dihderal Info' section to the ring fragment MCF file
+    ! Write the '# Dihedral Info' section to the ring fragment MCF file
     !------------------------------------------------------------------------------------------
     IMPLICIT NONE
 
@@ -1087,10 +1087,10 @@ CONTAINS
 
     DO idihed = 1, ndihedrals(is)
 
-       atom_1 = dihedral_list(idihed,is)%atom1
-       atom_2 = dihedral_list(idihed,is)%atom2
-       atom_3 = dihedral_list(idihed,is)%atom3
-       atom_4 = dihedral_list(idihed,is)%atom4
+       atom_1 = dihedral_list(idihed,is)%atom(1)
+       atom_2 = dihedral_list(idihed,is)%atom(2)
+       atom_3 = dihedral_list(idihed,is)%atom(3)
+       atom_4 = dihedral_list(idihed,is)%atom(4)
 
        ! loop over all the fragment atoms and see if all the four atoms are part of
        ! the fragement
@@ -1234,10 +1234,10 @@ CONTAINS
 
     DO imp_ang = 1, nimpropers(is)
 
-       atom_1 = improper_list(imp_ang,is)%atom1
-       atom_2 = improper_list(imp_ang,is)%atom2
-       atom_3 = improper_list(imp_ang,is)%atom3
-       atom_4 = improper_list(imp_ang,is)%atom4
+       atom_1 = improper_list(imp_ang,is)%atom(1)
+       atom_2 = improper_list(imp_ang,is)%atom(2)
+       atom_3 = improper_list(imp_ang,is)%atom(3)
+       atom_4 = improper_list(imp_ang,is)%atom(4)
 
        ! loop over the fragment atoms and determine if all the atoms belong to the fragment
 

--- a/Src/read_write_checkpoint.f90
+++ b/Src/read_write_checkpoint.f90
@@ -36,6 +36,7 @@ MODULE Read_Write_Checkpoint
   USE Simulation_Properties
   USE Random_Generators, ONLY : s1,s2,s3,s4,s5, rranf
   USE IO_Utilities
+  USE Internal_Coordinate_Routines
 
   IMPLICIT NONE
 

--- a/Src/ring_fragment_driver.f90
+++ b/Src/ring_fragment_driver.f90
@@ -170,8 +170,8 @@ SUBROUTINE ID_Multiring_Atoms(is)
            ! this_atom is at the apex
            angle_id = angle_part_list(this_atom, is)%which_angle(j)
            ! check if other atoms in the angle are ring atoms
-           atom1 = angle_list(angle_id, is)%atom1
-           atom2 = angle_list(angle_id, is)%atom3
+           atom1 = angle_list(angle_id, is)%atom(1)
+           atom2 = angle_list(angle_id, is)%atom(3)
            IF (nonbond_list(atom1, is)%ring_atom .AND. nonbond_list(atom2, is)%ring_atom) THEN
               ! If yes, increment counter
               atom_ring_count = atom_ring_count + 1

--- a/Src/type_definitions.f90
+++ b/Src/type_definitions.f90
@@ -246,7 +246,7 @@ MODULE Type_Definitions
   TYPE Bond_Class
 
      ! bond list has dimensions (MAXVAL(nbonds), nspecies)
-     INTEGER :: atom1, atom2, int_bond_type
+     INTEGER :: atom(2), int_bond_type
      REAL(DP), DIMENSION(max_bond_params) :: bond_param
      CHARACTER(20) :: bond_potential_type
 
@@ -261,7 +261,7 @@ MODULE Type_Definitions
      ! angle list has dimensions (MAXVAL(nangles,nspecies)
 
      ! 1 - 2 - 3 forms an angle with 2 at the apex.
-     INTEGER :: atom1, atom2, atom3
+     INTEGER :: atom(3)
 
      REAL(DP), DIMENSION(max_angle_params) :: angle_param
      CHARACTER(20) :: angle_potential_type
@@ -282,10 +282,14 @@ MODULE Type_Definitions
      ! defined sequentially (1-2-3-4) along dihedral angle, and parameters for the
      ! potential are held in an array.
 
-     INTEGER :: atom1, atom2, atom3, atom4
+     INTEGER :: atom(4)
+     ! RB torsion series constants
+     REAL(DP) :: rb_c(0:5)
      REAL(DP), DIMENSION(max_dihedral_params) :: dihedral_param
      CHARACTER(20) :: dihedral_potential_type
      INTEGER :: int_dipot_type
+     ! Flag to tell whether dihedral is formatted as RB torsion
+     LOGICAL :: l_rb_formatted
 
   END TYPE Dihedral_Class
   !****************************************************************************
@@ -300,7 +304,7 @@ MODULE Type_Definitions
      ! Describes an improper dihedral: atom 1 is the central atom, and atoms 2
      ! through 4 are attached to atom 1, parameters are stored in an array
 
-     INTEGER :: atom1, atom2, atom3, atom4
+     INTEGER :: atom(4)
      REAL(DP), DIMENSION(max_improper_params) :: improper_param
      CHARACTER(20) :: improper_potential_type
      INTEGER :: int_improp_type

--- a/Src/type_definitions.f90
+++ b/Src/type_definitions.f90
@@ -121,6 +121,9 @@ MODULE Type_Definitions
      INTEGER (KIND=INT64), DIMENSION(:), ALLOCATABLE :: insertions_in_step, widom_interval
      REAL(DP), DIMENSION(:), ALLOCATABLE :: widom_sum
 
+     ! # of RB dihedrals, # of dihedrals with nonzero energy, # of dihedrals before stacked dihedrals were combined
+     INTEGER :: ndihedrals_rb, ndihedrals_energetic, ndihedrals_uncombined
+
   END TYPE Species_Class
   !****************************************************************************
 


### PR DESCRIPTION
## Description
See linked issue.  This PR implements the suggested changes.
## Related Issue
Closes #146 

## How Has This Been Tested?
It passes the test suite.
The quintuple angle formula I derived myself for converting CHARMM dihedrals with periodicity 5 to RB torsions was tested with a calculator.

## Backward Compatibility
Technically, it now rejects AMBER as a dihedral style and thereby breaks backward compatibility.  However, AMBER dihedral style isn't in the documentation, nor does Cassandra actually compute energies for AMBER style dihedrals, so this break in backwards compatibility is more like fixing a bug.

## Post Submission Checklist
Please check the fields below as they are completed

- [ ] Suitable new documentation files and/or updates to the existing docs are included.
- [ ] One or more example input decks are included.
- [ ] Suitable tests were added to the test suite
- [ ] My name is in the contributor list at `/Documentation/source/reference/acknowledgements.rst`

## Further Information, Files, and Links
GROMACS does something similar: https://manual.gromacs.org/current/reference-manual/functions/bonded-interactions.html#proper-dihedrals-ryckaert-bellemans-function 
